### PR TITLE
nix/package.nix: set meta.mainProgram to "nixfmt"

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,5 +7,7 @@ rustPlatform.buildRustPackage {
   # The test suite shells out to the reference Haskell `nixfmt` to compare
   # output, so it must be on PATH during checkPhase.
   nativeCheckInputs = [ nixfmt ];
+  # The binary is named `nixfmt` (see Cargo.toml [[bin]]), not the pname.
+  # Without this, lib.getExe guesses `nixfmt-rs` and treefmt-nix breaks.
+  meta.mainProgram = "nixfmt";
 }
-


### PR DESCRIPTION
The Cargo [[bin]] target is named "nixfmt", but the derivation pname is
"nixfmt-rs". lib.getExe falls back to pname when meta.mainProgram is
unset, so consumers like treefmt-nix end up invoking a non-existent
bin/nixfmt-rs. Declare the actual binary name explicitly.
