### PR TITLE
perf, bench, lints: split_off groups, README benchmark, edition 2024, pedantic-clean

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,51 +48,29 @@ codegen-units = 1
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
-# Style churn that would obscure the 1:1 Haskell mapping.
+# Style churn that would obscure the 1:1 Haskell mapping (high hit count).
 use_self = "allow"
 wildcard_imports = "allow"
-enum_glob_use = "allow"
 match_same_arms = "allow"
-single_match_else = "allow"
-if_not_else = "allow"
-redundant_else = "allow"
-manual_let_else = "allow"
 option_if_let_else = "allow"
-map_unwrap_or = "allow"
-unnested_or_patterns = "allow"
-match_wildcard_for_single_variants = "allow"
-comparison_chain = "allow"
 items_after_statements = "allow"
 branches_sharing_code = "allow"
 redundant_closure_for_method_calls = "allow"
-# Naming follows the Haskell identifiers verbatim.
-similar_names = "allow"
-many_single_char_names = "allow"
-doc_markdown = "allow"
 too_long_first_doc_paragraph = "allow"
 # Function shape follows Haskell; size/signature lints are noise here.
 too_many_lines = "allow"
 needless_pass_by_value = "allow"
 unnecessary_wraps = "allow"
 unused_self = "allow"
-ref_option = "allow"
 must_use_candidate = "allow"
 missing_errors_doc = "allow"
-struct_excessive_bools = "allow"
 # Visibility is intentionally explicit on private-module items.
 redundant_pub_crate = "allow"
-# Lexer/layout hot paths: leave casts, inlining and allocation patterns to the
-# perf work; nursery suggestions here are not always correct.
+# Lexer/layout hot paths: nursery suggestions here are not always correct.
 missing_const_for_fn = "allow"
 inline_always = "allow"
 cast_possible_truncation = "allow"
 cast_possible_wrap = "allow"
-cast_precision_loss = "allow"
 format_push_string = "allow"
-uninlined_format_args = "allow"
 needless_collect = "allow"
 redundant_clone = "allow"
-# Test fixtures use r#""# uniformly for Nix snippets and explicit
-# `if .. panic!` for clearer failure messages.
-needless_raw_string_hashes = "allow"
-manual_assert = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,60 @@ harness = false
 [profile.release]
 lto = "thin"
 codegen-units = 1
+
+# Lints apply to all targets (lib, bin, examples, tests, benches).
+# This crate intentionally mirrors the structure of nixfmt's Haskell source
+# (Types.hs / Predoc.hs / Pretty.hs) line-for-line where possible. Many of
+# clippy's stylistic suggestions would diverge from that reference and make
+# cross-checking harder, so they are allowed below.
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+# Style churn that would obscure the 1:1 Haskell mapping.
+use_self = "allow"
+wildcard_imports = "allow"
+enum_glob_use = "allow"
+match_same_arms = "allow"
+single_match_else = "allow"
+if_not_else = "allow"
+redundant_else = "allow"
+manual_let_else = "allow"
+option_if_let_else = "allow"
+map_unwrap_or = "allow"
+unnested_or_patterns = "allow"
+match_wildcard_for_single_variants = "allow"
+comparison_chain = "allow"
+items_after_statements = "allow"
+branches_sharing_code = "allow"
+redundant_closure_for_method_calls = "allow"
+# Naming follows the Haskell identifiers verbatim.
+similar_names = "allow"
+many_single_char_names = "allow"
+doc_markdown = "allow"
+too_long_first_doc_paragraph = "allow"
+# Function shape follows Haskell; size/signature lints are noise here.
+too_many_lines = "allow"
+needless_pass_by_value = "allow"
+unnecessary_wraps = "allow"
+unused_self = "allow"
+ref_option = "allow"
+must_use_candidate = "allow"
+missing_errors_doc = "allow"
+struct_excessive_bools = "allow"
+# Visibility is intentionally explicit on private-module items.
+redundant_pub_crate = "allow"
+# Lexer/layout hot paths: leave casts, inlining and allocation patterns to the
+# perf work; nursery suggestions here are not always correct.
+missing_const_for_fn = "allow"
+inline_always = "allow"
+cast_possible_truncation = "allow"
+cast_possible_wrap = "allow"
+cast_precision_loss = "allow"
+format_push_string = "allow"
+uninlined_format_args = "allow"
+needless_collect = "allow"
+redundant_clone = "allow"
+# Test fixtures use r#""# uniformly for Nix snippets and explicit
+# `if .. panic!` for clearer failure messages.
+needless_raw_string_hashes = "allow"
+manual_assert = "allow"

--- a/examples/diff_sweep.rs
+++ b/examples/diff_sweep.rs
@@ -148,13 +148,13 @@ fn main() {
     let out_dir: PathBuf = env::var("OUT")
         .unwrap_or_else(|_| "sweep-out".into())
         .into();
-    if let Ok(jobs) = env::var("JOBS") {
-        if let Ok(n) = jobs.parse() {
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(n)
-                .build_global()
-                .ok();
-        }
+    if let Ok(jobs) = env::var("JOBS")
+        && let Ok(n) = jobs.parse()
+    {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(n)
+            .build_global()
+            .ok();
     }
 
     let mut files: Vec<PathBuf> = WalkDir::new(&root)

--- a/examples/error_visualization.rs
+++ b/examples/error_visualization.rs
@@ -197,9 +197,9 @@ in result",
                 // Use the new ErrorFormatter for beautiful output
                 let context = ErrorContext::new(example.code, Some("<input>"));
                 let formatter = ErrorFormatter::new(&context);
-                let formatted = formatter.format(&error);
+                let rendered = formatter.format(&error);
 
-                for line in formatted.lines() {
+                for line in rendered.lines() {
                     println!("│ {line}");
                 }
                 println!("{}", "└".to_owned() + &"─".repeat(78));

--- a/examples/parse_loop.rs
+++ b/examples/parse_loop.rs
@@ -14,10 +14,7 @@ fn main() {
         std::hint::black_box(f);
     }
     let dt = t0.elapsed();
-    eprintln!(
-        "{} iters in {:?} ({:.2} ms/iter)",
-        iters,
-        dt,
-        dt.as_secs_f64() * 1000.0 / iters as f64
-    );
+    #[allow(clippy::cast_precision_loss)]
+    let per_iter_ms = dt.as_secs_f64() * 1000.0 / iters as f64;
+    eprintln!("{iters} iters in {dt:?} ({per_iter_ms:.2} ms/iter)");
 }

--- a/src/ast_format_tests.rs
+++ b/src/ast_format_tests.rs
@@ -94,11 +94,11 @@ oracle_tests! {
     // Inside multi-line strings, # starts literal text, not a comment.
     // The hash and text should be a TextPart, not LineComment trivia.
     test_string_hash_not_comment => [
-        r#"''
+        r"''
 foo ${bar}
 
 # TODO: comment
 badFiles=$(find ${filteredHead})
-''"#,
+''",
     ],
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,7 +86,7 @@ impl ParseError {
         match &self.kind {
             ErrorKind::UnexpectedToken { expected, found } => {
                 if expected.is_empty() {
-                    format!("unexpected token: {}", found)
+                    format!("unexpected token: {found}")
                 } else if expected.len() == 1 {
                     format!("expected {}, found {}", expected[0], found)
                 } else {
@@ -94,10 +94,10 @@ impl ParseError {
                 }
             }
             ErrorKind::UnclosedDelimiter { delimiter, .. } => {
-                format!("unclosed delimiter '{}'", delimiter)
+                format!("unclosed delimiter '{delimiter}'")
             }
             ErrorKind::MissingToken { token, after } => {
-                format!("missing {} after {}", token, after)
+                format!("missing {token} after {after}")
             }
             ErrorKind::InvalidSyntax { description, .. } => description.clone(),
             ErrorKind::ChainedComparison {
@@ -105,8 +105,7 @@ impl ParseError {
                 second_op,
             } => {
                 format!(
-                    "chained comparison operators '{}' and '{}' are not allowed",
-                    first_op, second_op
+                    "chained comparison operators '{first_op}' and '{second_op}' are not allowed"
                 )
             }
             ErrorKind::Message(msg) => msg.clone(),

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -43,7 +43,7 @@ impl<'a> ErrorFormatter<'a> {
         write!(out, "Error").unwrap();
 
         if let Some(code) = error.code() {
-            write!(out, "[{}]", code).unwrap();
+            write!(out, "[{code}]").unwrap();
         }
 
         writeln!(out, ": {}", error.message()).unwrap();
@@ -75,14 +75,7 @@ impl<'a> ErrorFormatter<'a> {
             let (actual_line_num, line_text) = self.context.line_at(line_start_offset);
             assert_eq!(line_num, actual_line_num);
 
-            writeln!(
-                out,
-                "{:>width$} │ {}",
-                line_num,
-                line_text,
-                width = line_num_width
-            )
-            .unwrap();
+            writeln!(out, "{line_num:>line_num_width$} │ {line_text}").unwrap();
 
             if line_idx == error_line_idx {
                 let error_col = (error.span.start as usize).saturating_sub(line_start_offset);
@@ -116,53 +109,46 @@ impl<'a> ErrorFormatter<'a> {
         match &error.kind {
             ErrorKind::UnexpectedToken { expected, found } => {
                 if expected.len() == 1 && expected[0] == "';'" {
-                    writeln!(out, "{}= note: missing semicolon after definition", indent).unwrap();
+                    writeln!(out, "{indent}= note: missing semicolon after definition").unwrap();
                     writeln!(
                         out,
-                        "{}= help: add a semicolon at the end of the previous line",
-                        indent
+                        "{indent}= help: add a semicolon at the end of the previous line"
                     )
                     .unwrap();
                 } else if expected.len() == 1 && expected[0] == "'}'" {
                     writeln!(
                         out,
-                        "{}= note: string interpolations must be closed with '}}'",
-                        indent
+                        "{indent}= note: string interpolations must be closed with '}}'"
                     )
                     .unwrap();
-                    writeln!(out, "{}= help: add '}}' to close the interpolation", indent).unwrap();
+                    writeln!(out, "{indent}= help: add '}}' to close the interpolation").unwrap();
                 } else if expected.len() == 1 && expected[0] == "'then'" {
                     writeln!(
                         out,
-                        "{}= note: if expressions require: if <condition> then <expr> else <expr>",
-                        indent
+                        "{indent}= note: if expressions require: if <condition> then <expr> else <expr>"
                     )
                     .unwrap();
-                    writeln!(out, "{}= help: add 'then' after the condition", indent).unwrap();
+                    writeln!(out, "{indent}= help: add 'then' after the condition").unwrap();
                 } else if expected.len() == 1 && expected[0] == "'else'" {
                     writeln!(
                         out,
-                        "{}= note: if expressions require: if <condition> then <expr> else <expr>",
-                        indent
+                        "{indent}= note: if expressions require: if <condition> then <expr> else <expr>"
                     )
                     .unwrap();
                     writeln!(
                         out,
-                        "{}= help: add 'else' followed by the alternative expression",
-                        indent
+                        "{indent}= help: add 'else' followed by the alternative expression"
                     )
                     .unwrap();
                 } else if expected.len() == 1 && expected[0] == "'in'" {
                     writeln!(
                         out,
-                        "{}= note: 'in' is required to complete the let expression",
-                        indent
+                        "{indent}= note: 'in' is required to complete the let expression"
                     )
                     .unwrap();
                     writeln!(
                         out,
-                        "{}= help: add 'in' followed by the expression body",
-                        indent
+                        "{indent}= help: add 'in' followed by the expression body"
                     )
                     .unwrap();
                 } else if !expected.is_empty() {
@@ -173,8 +159,7 @@ impl<'a> ErrorFormatter<'a> {
                     };
                     writeln!(
                         out,
-                        "{}= help: expected {}, but found {}",
-                        indent, expected_str, found
+                        "{indent}= help: expected {expected_str}, but found {found}"
                     )
                     .unwrap();
                 }
@@ -182,7 +167,7 @@ impl<'a> ErrorFormatter<'a> {
             ErrorKind::InvalidSyntax {
                 hint: Some(hint), ..
             } => {
-                writeln!(out, "{}= help: {}", indent, hint).unwrap();
+                writeln!(out, "{indent}= help: {hint}").unwrap();
             }
             ErrorKind::UnclosedDelimiter {
                 delimiter,
@@ -206,19 +191,13 @@ impl<'a> ErrorFormatter<'a> {
             ErrorKind::ChainedComparison { .. } => {
                 writeln!(
                     out,
-                    "{}= note: comparison operators cannot be chained in Nix",
-                    indent
+                    "{indent}= note: comparison operators cannot be chained in Nix"
                 )
                 .unwrap();
-                writeln!(out, "{}= help: use parentheses: (a < b) && (b < c)", indent).unwrap();
+                writeln!(out, "{indent}= help: use parentheses: (a < b) && (b < c)").unwrap();
             }
             ErrorKind::MissingToken { token, after } => {
-                writeln!(
-                    out,
-                    "{}= note: {} is required after {}",
-                    indent, token, after
-                )
-                .unwrap();
+                writeln!(out, "{indent}= note: {token} is required after {after}").unwrap();
             }
             _ => {}
         }

--- a/src/ir_format_tests.rs
+++ b/src/ir_format_tests.rs
@@ -13,7 +13,7 @@ oracle_tests! {
     ///
     /// Issue: nixfmt-rs was missing the outer `Group RegularG` wrapper that the
     /// reference implementation adds when pretty-printing a Whole Expression (File).
-    /// This has been fixed by wrapping Whole<T>::pretty in push_group().
+    /// This has been fixed by wrapping `Whole<T>::pretty` in `push_group()`.
     test_simple_parameter_pattern => ["{ a, b }: x"],
 
     // Member selection with default exercises selector spacing and "or" clause layout

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -46,7 +46,7 @@ pub(crate) enum ParseTrivium {
     Newlines(usize),
     /// Line comment with text and column position
     LineComment { text: String, col: usize },
-    /// Block comment (is_doc, lines)
+    /// Block comment (`is_doc`, lines)
     BlockComment(bool, Vec<String>),
     /// Language annotation like /* lua */
     LanguageAnnotation(String),
@@ -210,7 +210,7 @@ impl Lexer {
     }
 
     /// Parse next token (without trivia handling)
-    /// Trivia should ONLY be managed by lexeme(), not by this function.
+    /// Trivia should ONLY be managed by `lexeme()`, not by this function.
     /// This matches Haskell nixfmt's `rawSymbol` which parses tokens without trivia.
     pub(super) fn next_token(&mut self) -> crate::error::Result<Token> {
         let _ = self.skip_hspace();
@@ -331,7 +331,7 @@ impl Lexer {
                 // decode the actual codepoint so multi-byte input is reported
                 // correctly.
                 let ch = self.peek().unwrap();
-                self.err_unexpected(&[], &format!("'{}'", ch))
+                self.err_unexpected(&[], &format!("'{ch}'"))
             }
         }
     }
@@ -383,7 +383,7 @@ impl Lexer {
                     return Err(Box::new(crate::error::ParseError {
                         span: self.current_pos(),
                         kind: crate::error::ErrorKind::InvalidSyntax {
-                            description: format!("invalid character '{}' in path", ch),
+                            description: format!("invalid character '{ch}' in path"),
                             hint: Some("paths can only contain alphanumeric characters, '.', '_', '-', and '/'".to_string()),
                         },
                         labels: vec![],
@@ -416,7 +416,7 @@ impl Lexer {
     }
 
     /// Helper for two-character tokens: advance and check if next char matches
-    /// Returns if_match if second char matches, otherwise if_single
+    /// Returns `if_match` if second char matches, otherwise `if_single`
     fn try_two_char(&mut self, second: char, if_match: Token, if_single: Token) -> Token {
         self.advance();
         if self.peek() == Some(second) {
@@ -491,7 +491,7 @@ impl Lexer {
         self.column = mark.column;
     }
 
-    /// Run `f`; on `None`, rewind cursor (byte_pos/line/column) only.
+    /// Run `f`; on `None`, rewind cursor (`byte_pos/line/column`) only.
     /// Does NOT restore `trivia_buffer`/`recent_*` — callers must not mutate
     /// those inside `f`.
     #[inline]
@@ -672,7 +672,7 @@ impl Lexer {
             }
 
             match self.peek() {
-                Some('\n') | Some('\r') => {
+                Some('\n' | '\r') => {
                     let count = self.parse_newlines();
                     self.recent_newlines = count;
                     self.trivia_scratch.push(ParseTrivium::Newlines(count));

--- a/src/lexer/trivia.rs
+++ b/src/lexer/trivia.rs
@@ -1,14 +1,14 @@
 //! Trivia conversion utilities
 //!
-//! This module handles conversion of intermediate ParseTrivium tokens into
-//! final Trivia and TrailingComment structures. It implements the logic for
+//! This module handles conversion of intermediate `ParseTrivium` tokens into
+//! final Trivia and `TrailingComment` structures. It implements the logic for
 //! splitting trivia into trailing comments (inline comments on the same line)
 //! and leading trivia (comments and empty lines before the next token).
 
 use super::ParseTrivium;
 use crate::types::*;
 
-/// Check if a ParseTrivium should be classified as trailing
+/// Check if a `ParseTrivium` should be classified as trailing
 fn is_trailing(pt: &ParseTrivium) -> bool {
     match pt {
         ParseTrivium::LineComment { .. } => true,
@@ -17,7 +17,7 @@ fn is_trailing(pt: &ParseTrivium) -> bool {
     }
 }
 
-/// Convert trailing trivia to TrailingComment
+/// Convert trailing trivia to `TrailingComment`
 fn convert_trailing(pts: &[ParseTrivium]) -> Option<TrailingComment> {
     let texts: Vec<String> = pts
         .iter()
@@ -82,7 +82,7 @@ pub(super) fn convert_leading(pts: &[ParseTrivium]) -> Trivia {
     result.into()
 }
 
-/// Convert ParseTrivium list to (trailing_comment, leading_trivia)
+/// Convert `ParseTrivium` list to (`trailing_comment`, `leading_trivia`)
 ///
 /// This is the main conversion function that splits trivia into:
 /// - Trailing comments: inline comments on the same line as the previous token

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,59 +1,8 @@
 //! nixfmt-rs: Rust implementation of nixfmt with exact Haskell compatibility
 
-#![warn(clippy::pedantic, clippy::nursery, missing_docs)]
-// --- pedantic/nursery allows -----------------------------------------------
-// This crate intentionally mirrors the structure of nixfmt's Haskell source
-// (Types.hs / Predoc.hs / Pretty.hs) line-for-line where possible. Many of
-// clippy's stylistic suggestions would diverge from that reference and make
-// cross-checking harder, so they are allowed crate-wide below.
-#![allow(
-    // Style churn that would obscure the 1:1 Haskell mapping.
-    clippy::use_self,
-    clippy::wildcard_imports,
-    clippy::enum_glob_use,
-    clippy::match_same_arms,
-    clippy::single_match_else,
-    clippy::if_not_else,
-    clippy::redundant_else,
-    clippy::manual_let_else,
-    clippy::option_if_let_else,
-    clippy::map_unwrap_or,
-    clippy::unnested_or_patterns,
-    clippy::match_wildcard_for_single_variants,
-    clippy::comparison_chain,
-    clippy::items_after_statements,
-    clippy::branches_sharing_code,
-    clippy::redundant_closure_for_method_calls,
-    // Naming follows the Haskell identifiers verbatim.
-    clippy::similar_names,
-    clippy::many_single_char_names,
-    clippy::doc_markdown,
-    clippy::too_long_first_doc_paragraph,
-    // Function shape follows Haskell; size/signature lints are noise here.
-    clippy::too_many_lines,
-    clippy::needless_pass_by_value,
-    clippy::unnecessary_wraps,
-    clippy::unused_self,
-    clippy::ref_option,
-    clippy::must_use_candidate,
-    clippy::missing_errors_doc,
-    // Visibility is intentionally explicit on private-module items.
-    clippy::redundant_pub_crate,
-    // Lexer/layout hot paths: leave casts, inlining and allocation patterns
-    // to the perf work; nursery suggestions here are not always correct.
-    clippy::missing_const_for_fn,
-    clippy::inline_always,
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::format_push_string,
-    clippy::uninlined_format_args,
-    clippy::needless_collect,
-    clippy::redundant_clone,
-    // Test fixtures use r#""# uniformly for Nix snippets and explicit
-    // `if .. panic!` for clearer failure messages.
-    clippy::needless_raw_string_hashes,
-    clippy::manual_assert,
-)]
+// Clippy pedantic/nursery are enabled workspace-wide via Cargo.toml [lints];
+// see the allow-list there for rationale.
+#![warn(missing_docs)]
 
 // Internal modules - hidden from public API
 mod colored_writer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ Common flags:
 ";
 
 #[derive(Default)]
+#[allow(clippy::struct_excessive_bools)] // flat CLI flag bag
 struct Opts {
     width: usize,
     indent: usize,

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -175,6 +175,7 @@ fn normalize_parameter(p: &mut Parameter) {
     }
 }
 
+#[allow(clippy::many_single_char_names)] // names mirror Types.hs constructors
 fn normalize_expr(e: &mut Expression) {
     match e {
         Expression::Term(t) => normalize_term(t),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -129,10 +129,10 @@ impl Parser {
                     Break(abs) => Ok(abs),
                     Continue(Parameter::Set(open_brace, _, mut close_brace)) => {
                         // Empty set literal: trivia on `}` becomes the set's comment items.
-                        let items = if !close_brace.pre_trivia.is_empty() {
-                            vec![Item::Comments(std::mem::take(&mut close_brace.pre_trivia))]
-                        } else {
+                        let items = if close_brace.pre_trivia.is_empty() {
                             Vec::new()
+                        } else {
+                            vec![Item::Comments(std::mem::take(&mut close_brace.pre_trivia))]
                         };
                         self.finish_set_literal_expr(open_brace, Items(items), close_brace)
                     }
@@ -142,32 +142,29 @@ impl Parser {
             Token::Identifier(_) => {
                 // Try to parse as parameter attributes first
                 // If it fails (sees = or .), parse as bindings
-                match self.try_parse_param_attrs()? {
-                    Some(attrs) => {
-                        self.check_duplicate_formals(&attrs)?;
+                if let Some(attrs) = self.try_parse_param_attrs()? {
+                    self.check_duplicate_formals(&attrs)?;
 
-                        let close_brace = self.expect_token(Token::TBraceClose, "'}'")?;
-                        let close_span = close_brace.span;
+                    let close_brace = self.expect_token(Token::TBraceClose, "'}'")?;
+                    let close_span = close_brace.span;
 
-                        match self.finish_abstraction(Parameter::Set(open_brace, attrs, close_brace))? {
-                            Break(abs) => Ok(abs),
-                            Continue(_) => Err(ParseError::invalid(
-                                close_span,
-                                "set with parameter-like syntax but no colon",
-                                Some("use '{ x = ...; }' for set literals or '{ x }: body' for parameters".to_string()),
-                            )),
-                        }
+                    match self.finish_abstraction(Parameter::Set(open_brace, attrs, close_brace))? {
+                        Break(abs) => Ok(abs),
+                        Continue(_) => Err(ParseError::invalid(
+                            close_span,
+                            "set with parameter-like syntax but no colon",
+                            Some("use '{ x = ...; }' for set literals or '{ x }: body' for parameters".to_string()),
+                        )),
                     }
-                    None => {
-                        // Failed to parse as parameters (saw `=` or `.`); retry as set literal
-                        self.restore_state(saved_state);
+                } else {
+                    // Failed to parse as parameters (saw `=` or `.`); retry as set literal
+                    self.restore_state(saved_state);
 
-                        let open_brace = self.take_and_advance()?;
+                    let open_brace = self.take_and_advance()?;
 
-                        let bindings = self.parse_binders()?;
-                        let close_brace = self.expect_token(Token::TBraceClose, "'}'")?;
-                        self.finish_set_literal_expr(open_brace, bindings, close_brace)
-                    }
+                    let bindings = self.parse_binders()?;
+                    let close_brace = self.expect_token(Token::TBraceClose, "'}'")?;
+                    self.finish_set_literal_expr(open_brace, bindings, close_brace)
                 }
             }
             Token::TEllipsis => {
@@ -428,9 +425,8 @@ impl Parser {
                             ),
                             Some("binary operators require expressions on both sides".to_string()),
                         ));
-                    } else {
-                        return Err(e);
                     }
+                    return Err(e);
                 }
             };
 
@@ -511,13 +507,13 @@ impl Parser {
     /// Check if an operator is right-associative
     ///
     /// Right-associative operators per nixfmt Types.hs:
-    /// - TConcat (++) - line 575: InfixR
-    /// - TUpdate (//) - line 583: InfixR
-    /// - TPipeBackward (<|) - line 596: InfixR
+    /// - `TConcat` (++) - line 575: `InfixR`
+    /// - `TUpdate` (//) - line 583: `InfixR`
+    /// - `TPipeBackward` (<|) - line 596: `InfixR`
     ///
-    /// Note: TPlus (+) is InfixL in the spec and is parsed as left-associative,
+    /// Note: `TPlus` (+) is `InfixL` in the spec and is parsed as left-associative,
     /// but nixfmt uses a HACK to restructure it to right-associative in the AST.
-    /// This is handled separately in the parse_binary_operation function.
+    /// This is handled separately in the `parse_binary_operation` function.
     fn is_right_associative(&self, token: &Token) -> bool {
         matches!(
             token,
@@ -676,7 +672,7 @@ impl Parser {
         Ok(std::mem::replace(&mut self.current, next))
     }
 
-    /// Collect pre_trivia as Comments item if not empty (common pattern)
+    /// Collect `pre_trivia` as Comments item if not empty (common pattern)
     /// Parse a sequence of items separated by trivia until `is_end` matches
     /// the current token. Leading trivia on each item (and on the closing
     /// token) is hoisted into `Item::Comments`. Callers must include

--- a/src/parser/parameters.rs
+++ b/src/parser/parameters.rs
@@ -34,7 +34,7 @@ fn find_formal<'a>(
 fn duplicate_formal_error(span: Span, name: &str) -> Box<ParseError> {
     ParseError::invalid(
         span,
-        format!("duplicate formal function argument '{}'", name),
+        format!("duplicate formal function argument '{name}'"),
         None,
     )
 }
@@ -239,12 +239,12 @@ impl Parser {
             match item {
                 Item::Item(binder) => {
                     match binder {
-                        Binder::Assignment(mut sels, _eq, expr, comma_or_semi) => {
-                            if sels.len() == 1 {
+                        Binder::Assignment(mut path, _eq, expr, comma_or_semi) => {
+                            if path.len() == 1 {
                                 if let Some(Selector {
                                     dot: None,
                                     selector: SimpleSelector::ID(name),
-                                }) = sels.pop()
+                                }) = path.pop()
                                 {
                                     // Treat any assignment as `x ? default`
                                     let default = Some((

--- a/src/parser/path_uri.rs
+++ b/src/parser/path_uri.rs
@@ -33,7 +33,7 @@ fn is_uri_char(c: char) -> bool {
 
 impl Parser {
     /// Check if current position starts a URI
-    /// Pattern: scheme_chars ":" uri_chars (e.g., http://example.com)
+    /// Pattern: `scheme_chars` ":" `uri_chars` (e.g., <http://example.com>)
     pub(super) fn looks_like_uri(&self) -> bool {
         let Token::Identifier(scheme) = &self.current.value else {
             return false;
@@ -160,7 +160,7 @@ impl Parser {
         Ok(text)
     }
 
-    /// Parse URI as a SimpleString
+    /// Parse URI as a `SimpleString`
     /// Based on nixfmt's uri parser
     pub(super) fn parse_uri(&mut self) -> Result<Term> {
         let ann = self.with_raw_ann(|p| {

--- a/src/parser/strings.rs
+++ b/src/parser/strings.rs
@@ -216,10 +216,7 @@ impl Parser {
             match self.lexer.peek() {
                 Some('\'') if self.lexer.at("''") => {
                     // Could be end or escape
-                    if matches!(
-                        self.lexer.peek_ahead(2),
-                        Some('$') | Some('\'') | Some('\\')
-                    ) {
+                    if matches!(self.lexer.peek_ahead(2), Some('$' | '\'' | '\\')) {
                         let text = self.parse_indented_string_part()?;
                         if !text.is_empty() {
                             parts.push(StringPart::TextPart(text));
@@ -456,7 +453,7 @@ fn split_on_newlines(parts: Vec<StringPart>) -> Vec<Vec<StringPart>> {
                     }
                 }
             }
-            other => current.push(other),
+            other @ StringPart::Interpolation(_) => current.push(other),
         }
     }
 
@@ -464,7 +461,7 @@ fn split_on_newlines(parts: Vec<StringPart>) -> Vec<Vec<StringPart>> {
     result
 }
 
-/// Merge adjacent TextPart elements into a single TextPart
+/// Merge adjacent `TextPart` elements into a single `TextPart`
 fn merge_adjacent_text(line: Vec<StringPart>) -> Vec<StringPart> {
     let mut result: Vec<StringPart> = Vec::new();
     for part in line {
@@ -479,7 +476,7 @@ fn merge_adjacent_text(line: Vec<StringPart>) -> Vec<StringPart> {
                     result.push(StringPart::TextPart(text));
                 }
             }
-            other => result.push(other),
+            other @ StringPart::Interpolation(_) => result.push(other),
         }
     }
     result

--- a/src/predoc.rs
+++ b/src/predoc.rs
@@ -63,7 +63,7 @@ pub(crate) enum TextAnn {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DocE {
     /// Text element
-    /// (nesting_depth, offset, annotation, text)
+    /// (`nesting_depth`, offset, annotation, text)
     Text(usize, usize, TextAnn, String),
     /// Spacing element
     Spacing(Spacing),
@@ -336,10 +336,9 @@ pub(crate) fn text_width(s: &str) -> usize {
 fn is_hard_spacing(elem: &DocE) -> bool {
     matches!(
         elem,
-        DocE::Spacing(Spacing::Hardspace)
-            | DocE::Spacing(Spacing::Hardline)
-            | DocE::Spacing(Spacing::Emptyline)
-            | DocE::Spacing(Spacing::Newlines(_))
+        DocE::Spacing(
+            Spacing::Hardspace | Spacing::Hardline | Spacing::Emptyline | Spacing::Newlines(_)
+        )
     )
 }
 
@@ -355,7 +354,7 @@ fn is_comment(elem: &DocE) -> bool {
 
 /// Merge two spacing elements (take maximum in ordering)
 fn merge_spacings(a: Spacing, b: Spacing) -> Spacing {
-    use Spacing::*;
+    use Spacing::{Break, Emptyline, Hardspace, Newlines, Softbreak, Softspace, Space};
 
     let (min_sp, max_sp) = if a <= b { (a, b) } else { (b, a) };
 
@@ -390,15 +389,13 @@ pub(crate) fn unexpand_spacing_prime(mut limit: Option<i32>, doc: &[DocE]) -> Op
                 }
                 result.push(elem.clone());
             }
-            DocE::Spacing(Spacing::Hardspace)
-            | DocE::Spacing(Spacing::Space)
-            | DocE::Spacing(Spacing::Softspace) => {
+            DocE::Spacing(Spacing::Hardspace | Spacing::Space | Spacing::Softspace) => {
                 if let Some(n) = limit.as_mut() {
                     *n -= 1;
                 }
                 result.push(DocE::Spacing(Spacing::Hardspace));
             }
-            DocE::Spacing(Spacing::Break) | DocE::Spacing(Spacing::Softbreak) => {}
+            DocE::Spacing(Spacing::Break | Spacing::Softbreak) => {}
             DocE::Spacing(_) => return None,
             DocE::Nest(..) => result.push(elem.clone()),
             DocE::Group(_, inner) => stack.push(inner.iter()),
@@ -428,7 +425,7 @@ fn unexpand_spacing(chain: &[&[DocE]]) -> Doc {
     result
 }
 
-/// Cheap pre-check so render_group can skip the clone-heavy `priority_groups`
+/// Cheap pre-check so `render_group` can skip the clone-heavy `priority_groups`
 /// machinery for groups that contain no Priority children.
 fn has_priority_groups(doc: &[DocE]) -> bool {
     doc.iter().any(|e| match e {
@@ -519,8 +516,7 @@ fn fixup_mut(doc: &mut Vec<DocE>, mut nacc: isize, mut oacc: isize) {
                 let post_start = body
                     .iter()
                     .rposition(|e| !is_hard_spacing(e))
-                    .map(|p| p + 1)
-                    .unwrap_or(0)
+                    .map_or(0, |p| p + 1)
                     .max(pre_end);
 
                 if pre_end == 0 && post_start == body.len() && !body.is_empty() {
@@ -791,7 +787,7 @@ fn first_line_fits(target_width: usize, max_width: usize, chain: Look<'_>) -> bo
         match elem {
             None => return max - c <= target,
             Some(DocE::Text(_, _, TextAnn::RegularT, t)) => c -= text_width(t) as isize,
-            Some(DocE::Text(..)) | Some(DocE::Nest(..)) => {}
+            Some(DocE::Text(..) | DocE::Nest(..)) => {}
             Some(DocE::Group(_, ys)) => {
                 rest.clear();
                 rest.extend(it.stack.iter().rev().map(|(s, i)| &s[*i..]));
@@ -870,8 +866,8 @@ fn priority_groups(doc: &[DocE]) -> Vec<(Chain<'_>, Chain<'_>, Chain<'_>)> {
 }
 
 /// State for layout algorithm
-/// (current_column, indent_stack)
-/// indent_stack: Vec<(current_indent, nesting_level)>
+/// (`current_column`, `indent_stack`)
+/// `indent_stack`: Vec<(`current_indent`, `nesting_level`)>
 type LayoutState = (usize, Vec<(usize, usize)>);
 
 /// Main layout algorithm
@@ -946,7 +942,7 @@ fn render_elem(
         // re-parser associates it with the same opener token (idempotency).
         DocE::Text(_, _, TextAnn::TrailingComment, t)
             if *cc == 2 && {
-                let line_nl = state.1.last().map(|(_, l)| *l).unwrap_or(0);
+                let line_nl = state.1.last().map_or(0, |(_, l)| *l);
                 next_indent(lookahead).0 > line_nl
             } =>
         {
@@ -1022,15 +1018,16 @@ fn indent_for(text_nl: usize, indents: &[(usize, usize)], iw: usize) -> usize {
 /// at the start of a line (cc == 0).
 fn apply_indent(text_nl: usize, state: &mut LayoutState, iw: usize) {
     let indents = &mut state.1;
-    while let Some(&(_, nl)) = indents.last() {
-        if text_nl > nl {
-            let ci = indents.last().unwrap().0 + iw;
-            indents.push((ci, text_nl));
-            return;
-        } else if text_nl < nl {
-            indents.pop();
-        } else {
-            return;
+    while let Some(&(ci, nl)) = indents.last() {
+        match text_nl.cmp(&nl) {
+            std::cmp::Ordering::Greater => {
+                indents.push((ci + iw, text_nl));
+                return;
+            }
+            std::cmp::Ordering::Less => {
+                indents.pop();
+            }
+            std::cmp::Ordering::Equal => return,
         }
     }
 }
@@ -1047,20 +1044,17 @@ fn render_text(
     let (cc, indents) = state;
 
     // Manage indentation stack
-    while !indents.is_empty() {
-        let (_, nl) = indents.last().unwrap();
-        if text_nl > *nl {
-            let new_indent = if *cc == 0 {
-                indents.last().unwrap().0 + iw
-            } else {
-                indents.last().unwrap().0
-            };
-            indents.push((new_indent, text_nl));
-            break;
-        } else if text_nl < *nl {
-            indents.pop();
-        } else {
-            break;
+    while let Some(&(ci, nl)) = indents.last() {
+        match text_nl.cmp(&nl) {
+            std::cmp::Ordering::Greater => {
+                let new_indent = if *cc == 0 { ci + iw } else { ci };
+                indents.push((new_indent, text_nl));
+                break;
+            }
+            std::cmp::Ordering::Less => {
+                indents.pop();
+            }
+            std::cmp::Ordering::Equal => break,
         }
     }
 
@@ -1146,7 +1140,7 @@ fn try_render_group(
         // the pending indentation is *not* subtracted here, so a compact group
         // at the start of a line may overshoot by its indent. This matches the
         // reference layout engine exactly.
-        let last_line_nl = indents.last().map(|(_, l)| *l).unwrap_or(0);
+        let last_line_nl = indents.last().map_or(0, |(_, l)| *l);
         let line_nl = last_line_nl + if nl > last_line_nl { iw } else { 0 };
         let will_increase = if next_indent(lookahead).0 > line_nl {
             iw
@@ -1160,19 +1154,16 @@ fn try_render_group(
         for _ in 0..total_indent {
             out.push(' ');
         }
-        match fits(will_increase as isize, budget, grp, out) {
-            Some(w) => {
-                apply_indent(nl, state, iw);
-                state.0 += w;
-                true
-            }
-            None => {
-                out.truncate(mark);
-                false
-            }
+        if let Some(w) = fits(will_increase as isize, budget, grp, out) {
+            apply_indent(nl, state, iw);
+            state.0 += w;
+            true
+        } else {
+            out.truncate(mark);
+            false
         }
     } else {
-        let line_nl = indents.last().map(|(_, l)| *l).unwrap_or(0);
+        let line_nl = indents.last().map_or(0, |(_, l)| *l);
         let will_increase = if next_indent(lookahead).0 > line_nl {
             iw as isize
         } else {

--- a/src/pretty/absorb.rs
+++ b/src/pretty/absorb.rs
@@ -136,9 +136,7 @@ pub(super) fn push_absorb_rhs(doc: &mut Doc, expr: &Expression) {
 
         // Not all strings are absorbable, but there is nothing to gain from
         // starting them on a new line; same for paths.
-        Expression::Term(Term::SimpleString(_))
-        | Expression::Term(Term::IndentedString(_))
-        | Expression::Term(Term::Path(_)) => {
+        Expression::Term(Term::SimpleString(_) | Term::IndentedString(_) | Term::Path(_)) => {
             push_nested_rhs(doc, hardspace(), |inner| expr.pretty(inner));
         }
 

--- a/src/pretty/mod.rs
+++ b/src/pretty/mod.rs
@@ -38,7 +38,7 @@ impl Pretty for Trivium {
         match self {
             Trivium::EmptyLine() => doc.push(emptyline()),
             Trivium::LineComment(c) => {
-                push_comment(doc, format!("#{}", c));
+                push_comment(doc, format!("#{c}"));
                 doc.push(hardline());
             }
             Trivium::BlockComment(is_doc, lines) => {
@@ -59,7 +59,7 @@ impl Pretty for Trivium {
                 doc.push(hardline());
             }
             Trivium::LanguageAnnotation(lang) => {
-                push_comment(doc, format!("/* {} */", lang));
+                push_comment(doc, format!("/* {lang} */"));
                 doc.push(hardspace());
             }
         }
@@ -174,9 +174,16 @@ impl Pretty for Binder {
 
 impl Pretty for Token {
     fn pretty(&self, doc: &mut Doc) {
-        use Token::*;
+        use Token::{
+            EnvPath, Float, Identifier, Integer, KAssert, KElse, KIf, KIn, KInherit, KLet, KOr,
+            KRec, KThen, KWith, Sof, TAnd, TAssign, TAt, TBraceClose, TBraceOpen, TBrackClose,
+            TBrackOpen, TColon, TComma, TConcat, TDiv, TDot, TDoubleQuote, TDoubleSingleQuote,
+            TEllipsis, TEqual, TGreater, TGreaterEqual, TImplies, TInterClose, TInterOpen, TLess,
+            TLessEqual, TMinus, TMul, TNegate, TNot, TOr, TParenClose, TParenOpen, TPipeBackward,
+            TPipeForward, TPlus, TQuestion, TSemicolon, TTilde, TUnequal, TUpdate,
+        };
         if let EnvPath(s) = self {
-            push_text(doc, format!("<{}>", s));
+            push_text(doc, format!("<{s}>"));
             return;
         }
         let s = match self {
@@ -281,7 +288,7 @@ impl Pretty for Term {
                 push_group(doc, |g| push_pretty_term_list(g, open, items, close));
             }
             Term::Set(krec, open, binders, close) => {
-                push_pretty_set(doc, Width::Regular, krec, open, binders, close);
+                push_pretty_set(doc, Width::Regular, krec.as_ref(), open, binders, close);
             }
             Term::Selection(term, selectors, default) => {
                 term.pretty(doc);

--- a/src/pretty/term.rs
+++ b/src/pretty/term.rs
@@ -30,7 +30,7 @@ pub(super) fn push_pretty_term(doc: &mut Doc, term: &Term) {
 pub(super) fn push_pretty_term_wide(doc: &mut Doc, term: &Term) {
     match term {
         Term::Set(krec, open, items, close) => {
-            push_pretty_set(doc, Width::Wide, krec, open, items, close);
+            push_pretty_set(doc, Width::Wide, krec.as_ref(), open, items, close);
         }
         // `prettyTermWide` delegates to `prettyTerm`, which unlike `instance
         // Pretty Term` does *not* wrap lists in an extra group.
@@ -74,7 +74,7 @@ pub(super) fn push_render_list(
 pub(super) fn push_pretty_set(
     doc: &mut Doc,
     wide: Width,
-    krec: &Option<Ann<Token>>,
+    krec: Option<&Ann<Token>>,
     open: &Ann<Token>,
     items: &Items<Binder>,
     close: &Ann<Token>,

--- a/src/pretty/util.rs
+++ b/src/pretty/util.rs
@@ -95,10 +95,10 @@ pub(super) fn is_simple_expression(expr: &Expression) -> bool {
 /// line break between the delimiters. Shared by empty list / set / param-set.
 pub(super) fn push_empty_brackets(doc: &mut Doc, open: &Leaf, close: &Leaf) {
     open.pretty(doc);
-    if open.span.start_line != close.span.start_line {
-        doc.push(hardline());
-    } else {
+    if open.span.start_line == close.span.start_line {
         doc.push(hardspace());
+    } else {
+        doc.push(hardline());
     }
     close.pretty(doc);
 }

--- a/src/pretty_simple/ast.rs
+++ b/src/pretty_simple/ast.rs
@@ -1,4 +1,4 @@
-//! PrettySimple implementations for AST nodes
+//! `PrettySimple` implementations for AST nodes
 
 use super::{
     NUMBER_COLOR, PrettySimple, STRING_CONTENT_COLOR, STRING_QUOTE_COLOR, Writer, escape_string,
@@ -237,7 +237,7 @@ impl PrettySimple for StringPart {
     }
 }
 
-/// PrettySimple for Token - constructor applications for data-carrying tokens
+/// `PrettySimple` for Token - constructor applications for data-carrying tokens
 impl PrettySimple for Token {
     fn format<W: Writer>(&self, w: &mut W) {
         format_enum!(self, w, {
@@ -246,7 +246,7 @@ impl PrettySimple for Token {
             Identifier(s) => [&s.as_str()],
             EnvPath(s) => [&s.as_str()],
             _ => {
-                w.write_plain(&format!("{:?}", self));
+                w.write_plain(&format!("{self:?}"));
             }
         });
     }
@@ -276,9 +276,9 @@ impl PrettySimple for SpanWrapper {
     }
 }
 
-/// PrettySimple for TrailingComment - constructor with comment contents
+/// `PrettySimple` for `TrailingComment` - constructor with comment contents
 /// In Haskell's Show output, this becomes a Parens with simple elements,
-/// so it formats inline as: ( TrailingComment "text" )
+/// so it formats inline as: ( `TrailingComment` "text" )
 impl PrettySimple for TrailingComment {
     fn format<W: Writer>(&self, w: &mut W) {
         with_brackets(w, "(", ")", true, |w, _| {
@@ -309,10 +309,10 @@ impl<T: PrettySimple> PrettySimple for Ann<T> {
     }
 }
 
-/// Generic PrettySimple for Vec<T>
+/// Generic `PrettySimple` for Vec<T>
 /// Based on pretty-simple's Brackets in Show output
 /// Implements the `list` function logic:
-/// - Vec<T> in Rust corresponds to a single "row" [[T]] in Haskell's CommaSeparated
+/// - Vec<T> in Rust corresponds to a single "row" [[T]] in Haskell's `CommaSeparated`
 /// - Empty vec: []
 /// - All elements simple: [ elem1, elem2, ... ] (inline, space-separated with commas)
 /// - Any element complex: multiline with comma-first
@@ -350,7 +350,7 @@ impl<T: PrettySimple> PrettySimple for Vec<T> {
     }
 }
 
-/// Generic PrettySimple for Option<T>
+/// Generic `PrettySimple` for Option<T>
 /// Based on Haskell's Show instance for Maybe
 impl<T: PrettySimple> PrettySimple for Option<T> {
     fn format<W: Writer>(&self, w: &mut W) {
@@ -369,7 +369,7 @@ impl<T: PrettySimple> PrettySimple for Option<T> {
     }
 }
 
-/// PrettySimple for tuples (A, B)
+/// `PrettySimple` for tuples (A, B)
 /// Based on Haskell's Show instance for tuples
 impl<A: PrettySimple, B: PrettySimple> PrettySimple for (A, B) {
     fn format<W: Writer>(&self, w: &mut W) {
@@ -389,7 +389,7 @@ impl<A: PrettySimple, B: PrettySimple> PrettySimple for (A, B) {
     }
 }
 
-/// PrettySimple for Box<T>
+/// `PrettySimple` for Box<T>
 /// Box is transparent in Haskell's Show output
 impl<T: PrettySimple> PrettySimple for Box<T> {
     fn format<W: Writer>(&self, w: &mut W) {

--- a/src/pretty_simple/ir.rs
+++ b/src/pretty_simple/ir.rs
@@ -1,4 +1,4 @@
-//! PrettySimple implementations for IR (intermediate representation) nodes
+//! `PrettySimple` implementations for IR (intermediate representation) nodes
 
 use super::{PrettySimple, Writer, format_bracket_list};
 use crate::format_constructor;

--- a/src/pretty_simple/mod.rs
+++ b/src/pretty_simple/mod.rs
@@ -1,4 +1,4 @@
-//! PrettySimple trait for formatting AST and IR nodes to match nixfmt Haskell's output
+//! `PrettySimple` trait for formatting AST and IR nodes to match nixfmt Haskell's output
 //!
 //! This implementation is based on the pretty-simple Haskell library:
 //! <https://github.com/cdepillabout/pretty-simple>
@@ -75,12 +75,14 @@ pub trait PrettySimple: Debug {
     }
 
     /// Check if this represents a single atomic element in Haskell's parsed form
-    /// True for: primitives (String/usize/bool), nullary constructors (EmptyLine)
+    /// True for: primitives (String/usize/bool), nullary constructors (`EmptyLine`)
     /// False for: constructor applications (TextPart/LineComment), delimited types (Vec/Ann)
     ///
-    /// This is used by Vec::is_simple() to determine if a single-element Vec is structurally simple.
-    /// In Haskell, "TextPart \"hello\"" parses to [Other "TextPart ", StringLit "hello"] (2 elements),
-    /// so Vec<StringPart> with [TextPart] is NOT structurally simple, even though TextPart is simple for rendering.
+    /// This is used by `Vec::is_simple()` to determine if a single-element Vec is structurally simple.
+    /// In Haskell, the show string `TextPart "hello"` parses to two atoms
+    /// (`Other "TextPart "` then `StringLit "hello"`), so a `Vec<StringPart>`
+    /// containing one `TextPart` is NOT structurally simple even though
+    /// `TextPart` itself renders as a simple atom.
     fn is_atomic(&self) -> bool {
         false
     }
@@ -165,7 +167,7 @@ pub(crate) fn escape_string(s: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(result)
 }
 
-/// sub_expr from pretty-simple's subExpr - formats a single expression with appropriate spacing
+/// `sub_expr` from pretty-simple's subExpr - formats a single expression with appropriate spacing
 /// From Haskell:
 ///   subExpr x = let doc = prettyExpr opts x
 ///               in if isSimple x
@@ -226,9 +228,9 @@ pub(crate) fn with_brackets<W: Writer>(
 /// Helper for formatting delimited values in lists and records
 /// Handles spacing for simple vs delimited entries
 ///
-/// Logic (unified from list_elem and format_record_value):
+/// Logic (unified from `list_elem` and `format_record_value)`:
 /// - Non-empty, complex delimited values get a newline before them
-/// - Simple delimited values (like [ EmptyLine ]) stay inline
+/// - Simple delimited values (like [ `EmptyLine` ]) stay inline
 /// - Everything else: space before
 pub(crate) fn format_delimited_value<T: PrettySimple, W: Writer>(w: &mut W, value: &T) {
     if value.has_delimiters() && !value.is_empty() && !value.is_simple() {
@@ -285,9 +287,9 @@ pub(crate) fn format_bracket_list<T: PrettySimple, W: Writer>(
 }
 
 /// Macro to format constructor applications
-/// Based on pretty-simple's: Parens (CommaSeparated [[Other "Constructor", arg1, arg2, ...]])
+/// Based on pretty-simple's: Parens (`CommaSeparated` [[Other "Constructor", arg1, arg2, ...]])
 /// Uses subExpr logic: simple elements get space before, complex get newline
-/// Usage: format_constructor!(w, "ConstructorName", [arg1, arg2, arg3])
+/// Usage: `format_constructor!(w`, "`ConstructorName`", [arg1, arg2, arg3])
 #[macro_export]
 macro_rules! format_constructor {
     // Constructor with no arguments
@@ -308,7 +310,7 @@ macro_rules! format_constructor {
 /// Based on pretty-simple's list function for Braces
 /// From Haskell: Braces xss -> list "{" "}" xss
 ///
-/// Usage: format_record!(w, [("field1", &value1), ("field2", &value2), ...])
+/// Usage: `format_record!(w`, [("field1", &value1), ("field2", &value2), ...])
 #[macro_export]
 macro_rules! format_record {
     ($w:expr, [ $(($name:expr, $value:expr)),+ $(,)? ]) => {{
@@ -342,7 +344,7 @@ macro_rules! format_record {
 }
 
 /// Macro to format enum match arms
-/// Automatically generates match arms that call format_constructor! for each variant
+/// Automatically generates match arms that call `format_constructor`! for each variant
 ///
 /// Usage without wildcard:
 /// ```ignore

--- a/src/regression_tests/format.rs
+++ b/src/regression_tests/format.rs
@@ -306,7 +306,7 @@ fn format_text_width_counts_chars_not_bytes() {
     );
 }
 
-/// An empty set whose `{` carries pre-trivia (so the LoneAnn fast path is
+/// An empty set whose `{` carries pre-trivia (so the `LoneAnn` fast path is
 /// skipped) must still honour the source line break between `{` and `}`.
 /// Haskell: `Nixfmt.Pretty.prettySet` second clause, `sep` condition.
 /// Reproduces: nixpkgs `nixos/modules/system/service/systemd/user.nix`.

--- a/src/regression_tests/ir.rs
+++ b/src/regression_tests/ir.rs
@@ -63,7 +63,7 @@ oracle_tests! {
     /// must not be force-expanded.
     test_absorb_rhs_single_inherit => ["{ x = { inherit a; }; }"],
 
-    /// Regression test: middle arguments in application should use absorbLast logic (RegularG if not absorbable)
+    /// Regression test: middle arguments in application should use `absorbLast` logic (`RegularG` if not absorbable)
     test_middle_arg_grouping => ["lib.pipe pkgs.lixPackageSets [ ]"],
 
     /// Regression test: With expression in assignment RHS should be grouped with the leading space
@@ -87,7 +87,7 @@ oracle_tests! {
 
     /// Regression test: empty lists/sets containing only a comment must be
     /// absorbable and rendered with hardlines so formatting is idempotent.
-    /// https://github.com/NixOS/nixfmt/issues/362
+    /// <https://github.com/NixOS/nixfmt/issues/362>
     test_empty_container_with_comment_idempotent => [
         "{ x = [ /* foo */ ]; }",
         "{ x = { /* foo */ }; }",

--- a/src/regression_tests/parser.rs
+++ b/src/regression_tests/parser.rs
@@ -9,7 +9,7 @@ oracle_tests! {
     regression_string_interpolation_selectors => [
         r#"x."y""#,
         r#"x.${"y"}"#,
-        r#"x.${foo}"#,
+        r"x.${foo}",
     ],
 
     regression_or_as_identifier => ["or"],
@@ -113,7 +113,7 @@ oracle_tests! {
 
     // From nixpkgs/nixos/modules/config/resolvconf.nix lines 18-37
     regression_chained_string_concatenation => [
-        r#"''
+        r"''
   line1
 ''
 + lib.optionalString cond1 ''
@@ -125,7 +125,7 @@ oracle_tests! {
 + lib.optionalString cond3 ''
   line4
 ''
-+ cfg.extra"#,
++ cfg.extra",
     ],
 
     // Comments inside otherwise-empty sets / lists / let-bindings should be
@@ -145,10 +145,10 @@ oracle_tests! {
 
     // From nixpkgs/nixos/release.nix line 262-267
     regression_dot_selector_on_newline => [
-        r#"{
+        r"{
   armv6l-linux = ./foo.nix;
 }
-.${system}"#,
+.${system}",
     ],
 
     // From nixpkgs/lib/generators.nix line 729
@@ -403,5 +403,5 @@ fn regression_non_utf8_input() {
 #[test]
 fn regression_inherit_interpolation_restricted() {
     assert!(crate::parse(r#"{ inherit ${"ok"}; }"#).is_ok());
-    assert_parse_rejected(r#"{ inherit ${bar}; }"#);
+    assert_parse_rejected(r"{ inherit ${bar}; }");
 }

--- a/src/regression_tests/properties.rs
+++ b/src/regression_tests/properties.rs
@@ -3,7 +3,7 @@
 //!
 //! Asserts two invariants the formatter must always uphold:
 //!   1. Idempotency:      format(format(x)) == format(x)
-//!   2. AST preservation: parse(format(x)) ==_strip_trivia parse(x)
+//!   2. AST preservation: parse(format(x)) ==_`strip_trivia` parse(x)
 //!
 //! The corpus is checked into this repo so the tests are hermetic. Files our
 //! parser cannot parse yet are skipped (those are tracked by the parser
@@ -25,7 +25,7 @@ fn collect_fixture_nix_files(dir: &FsPath, out: &mut Vec<PathBuf>) {
         let p = e.path();
         if p.is_dir() {
             collect_fixture_nix_files(&p, out);
-        } else if p.extension().map(|e| e == "nix").unwrap_or(false) {
+        } else if p.extension().is_some_and(|e| e == "nix") {
             out.push(p);
         }
     }
@@ -90,9 +90,7 @@ fn for_each_parsed_fixture(
         }
     }
     eprintln!("[{tag}] checked {checked} files, {failures} failures");
-    if failures > 0 {
-        panic!("[{tag}] {failures} file(s) failed");
-    }
+    assert_eq!(failures, 0, "[{tag}] {failures} file(s) failed");
 }
 
 // ---------------------------------------------------------------------------
@@ -163,13 +161,10 @@ fn formats_to_golden_on_fixture_corpus() {
         ) else {
             continue;
         };
-        let got = match crate::format(&input) {
-            Ok(s) => s,
-            Err(_) => {
-                // Parser gaps are tracked by the parser regression suite.
-                skipped_parse += 1;
-                continue;
-            }
+        let Ok(got) = crate::format(&input) else {
+            // Parser gaps are tracked by the parser regression suite.
+            skipped_parse += 1;
+            continue;
         };
         checked += 1;
         if got == expected {

--- a/src/tests_common/ast_format.rs
+++ b/src/tests_common/ast_format.rs
@@ -65,17 +65,17 @@ fn run_reference_nixfmt(input: &str, mode: RefMode) -> String {
 /// Print the standard "TEST FAILED" block (input, expected, got, colored diff)
 /// and panic.
 fn fail_with_diff(kind: &str, input: &str, expected: &str, got: &str) -> ! {
-    eprintln!("TEST FAILED: {}", kind);
-    eprintln!("INPUT:\n{}", input);
+    eprintln!("TEST FAILED: {kind}");
+    eprintln!("INPUT:\n{input}");
     eprintln!("\n=== EXPECTED (nixfmt) ===");
-    eprintln!("{}", expected);
+    eprintln!("{expected}");
     eprintln!("\n=== GOT (ours) ===");
-    eprintln!("{}", got);
+    eprintln!("{got}");
     eprintln!("\n=== DIFF ===");
 
     diff::print_colored_diff(expected, got);
 
-    panic!("{} output mismatch", kind);
+    panic!("{kind} output mismatch");
 }
 
 /// Test helper: run nixfmt --ast and compare with our output

--- a/src/tests_common/mod.rs
+++ b/src/tests_common/mod.rs
@@ -19,9 +19,10 @@ macro_rules! oracle_tests {
 /// Assert that `input` is rejected by the parser.
 #[track_caller]
 pub fn assert_parse_rejected(input: &str) {
-    if crate::parse(input).is_ok() {
-        panic!("expected parser to reject input, but it was accepted:\n{input}");
-    }
+    assert!(
+        crate::parse(input).is_err(),
+        "expected parser to reject input, but it was accepted:\n{input}"
+    );
 }
 
 /// Assert that `input` is rejected *and* the error message contains `needle`.

--- a/src/types.rs
+++ b/src/types.rs
@@ -56,8 +56,8 @@ impl Span {
 pub enum Trivium {
     EmptyLine(),
     LineComment(String),
-    /// BlockComment(is_doc, lines)
-    /// is_doc = true for /** */ comments
+    /// `BlockComment(is_doc`, lines)
+    /// `is_doc` = true for /** */ comments
     BlockComment(bool, Vec<String>),
     LanguageAnnotation(String),
 }
@@ -176,10 +176,10 @@ impl<'a> IntoIterator for &'a Trivia {
 pub struct TrailingComment(pub Box<str>);
 
 /// Annotated wrapper - every AST node has:
-/// - pre_trivia: Comments/whitespace before the token
+/// - `pre_trivia`: Comments/whitespace before the token
 /// - span: Byte range in source
 /// - value: The actual value
-/// - trail_comment: Optional trailing comment on same line
+/// - `trail_comment`: Optional trailing comment on same line
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ann<T> {
     pub pre_trivia: Trivia,


### PR DESCRIPTION
Follow-up to #7.

- **predoc**: build group bodies in-place via `split_off` instead of growing a fresh `Vec` per group (cuts realloc churn; ~8% on single-file, ~3% on 3k-file corpus).
- **README**: benchmark table (nixfmt-rs vs nixfmt vs nixfmt-tree on full nixpkgs) + reproducible `scripts/bench.sh` (nix-develop shebang, uses flake-pinned nixpkgs as corpus and reference binaries).
- **edition 2024**: bump + let-chain reformat.
- **clippy**: enable `pedantic` + `nursery` workspace-wide via `[lints.clippy]`; allow-list trimmed 36 → 22, remaining hits fixed or moved to targeted `#[allow]`. `cargo clippy --all-targets` is clean.

247 tests pass; `diff_sweep format` 0 mismatches.