### PR TITLE
wasm: surface the CLI's diagnostics to the playground

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -13,10 +13,12 @@ use wasm_bindgen::prelude::*;
 /// Format a Nix expression with default layout (width 100, indent 2).
 ///
 /// # Errors
-/// Throws a JS exception with the parse error message on invalid Nix.
+/// Throws a JS exception whose message is the same multi-line diagnostic
+/// the CLI prints (snippet + caret + hint). ANSI escapes are stripped
+/// since browser DOM nodes don't render them.
 #[wasm_bindgen]
 pub fn format(source: &str) -> Result<String, JsError> {
-    nixfmt_rs::format(source).map_err(|e| JsError::new(&e.to_string()))
+    format_with(source, 100, 2)
 }
 
 /// Format a Nix expression with explicit `width` (line width) and `indent`
@@ -26,5 +28,28 @@ pub fn format(source: &str) -> Result<String, JsError> {
 /// See [`format`].
 #[wasm_bindgen]
 pub fn format_with(source: &str, width: usize, indent: usize) -> Result<String, JsError> {
-    nixfmt_rs::format_with(source, width, indent).map_err(|e| JsError::new(&e.to_string()))
+    nixfmt_rs::format_with(source, width, indent).map_err(|e| {
+        let pretty = nixfmt_rs::format_error(source, None, &e);
+        JsError::new(&strip_ansi(&pretty))
+    })
+}
+
+/// Drop ANSI SGR escape sequences (`\x1b[...m`). The CLI formatter colours
+/// its output for terminals; the playground renders plain text in a `<pre>`.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' && chars.peek() == Some(&'[') {
+            chars.next();
+            for term in chars.by_ref() {
+                if term.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }

--- a/web/index.html
+++ b/web/index.html
@@ -212,7 +212,7 @@
         outline: none;
         resize: none;
       }
-      pre.error { color: var(--error); white-space: pre-wrap; }
+      pre.error { color: var(--error); white-space: pre; }
       textarea::placeholder { color: var(--muted); }
 
       @media (max-width: 800px) {


### PR DESCRIPTION

The wasm wrapper was using ParseError's bare Display impl, which only
prints "Parse error at byte N: <msg>". Users browsing the playground
got far worse feedback than CLI users for the same input.

Route errors through nixfmt_rs::format_error to produce the same
multi-line snippet + caret + hint output, then strip ANSI escapes since
the page renders into a `<pre>` rather than a terminal.


