### PR TITLE
add release script + ci

### DIFF
--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+cd "$SCRIPT_DIR/.."
+
+version="${1:-}"
+if [[ -z $version ]]; then
+  echo "USAGE: $0 version" >&2
+  exit 1
+fi
+
+if [[ "$(git symbolic-ref --short HEAD)" != "main" ]]; then
+  echo "must be on main branch" >&2
+  exit 1
+fi
+
+waitForPr() {
+  local pr=$1
+  while true; do
+    if gh pr view "$pr" | grep -q 'MERGED'; then
+      break
+    fi
+    echo "Waiting for PR to be merged..."
+    sleep 5
+  done
+}
+
+# ensure we are up-to-date
+uncommitted_changes=$(git diff --compact-summary)
+if [[ -n $uncommitted_changes ]]; then
+  echo -e "There are uncommitted changes, exiting:\n${uncommitted_changes}" >&2
+  exit 1
+fi
+git pull git@github.com:Mic92/nixfmt-rs main
+unpushed_commits=$(git log --format=oneline origin/main..main)
+if [[ $unpushed_commits != "" ]]; then
+  echo -e "\nThere are unpushed changes, exiting:\n$unpushed_commits" >&2
+  exit 1
+fi
+# make sure tag does not exist
+if git tag -l | grep -q "^${version}\$"; then
+  echo "Tag ${version} already exists, exiting" >&2
+  exit 1
+fi
+sed -i -e "0,/^version = \".*\"/s!^version = \".*\"!version = \"${version}\"!" Cargo.toml
+sed -i -e "s!version = \".*\";!version = \"${version}\";!" nix/package.nix
+cargo update --workspace --offline # bump version in Cargo.lock
+git add Cargo.toml Cargo.lock nix/package.nix
+git branch -D "release-${version}" || true
+git checkout -b "release-${version}"
+git commit -m "bump version ${version}"
+git push origin "release-${version}"
+pr_url=$(gh pr create \
+  --base main \
+  --head "release-${version}" \
+  --title "Release ${version}" \
+  --body "Release ${version} of nixfmt-rs")
+
+# Extract PR number from URL
+pr_number=$(echo "$pr_url" | grep -oE '[0-9]+$')
+
+# Enable auto-merge with specific merge method and delete branch
+gh pr merge "$pr_number" --auto --merge --delete-branch
+git checkout main
+
+waitForPr "release-${version}"
+git pull git@github.com:Mic92/nixfmt-rs main
+gh release create "${version}" --draft --title "${version}" --notes ""

--- a/flake.nix
+++ b/flake.nix
@@ -37,8 +37,13 @@
       });
 
       formatter = forAllSystems (system: treefmtEvalFor.${system}.config.build.wrapper);
-      checks = forAllSystems (system: {
-        formatting = treefmtEvalFor.${system}.config.build.check self;
-      });
+      checks = forAllSystems (
+        system:
+        # buildbot-nix builds .#checks; expose packages here so CI builds them.
+        self.packages.${system}
+        // {
+          formatting = treefmtEvalFor.${system}.config.build.check self;
+        }
+      );
     };
 }


### PR DESCRIPTION

Mirrors nix-update's bin/create-release.sh: bumps version in Cargo.toml,
Cargo.lock and nix/package.nix, opens a release PR, auto-merges it once
buildbot passes, then creates a draft GitHub release. Goes together with
the newly-enabled branch protection on main requiring buildbot/nix-build.
