### PR TITLE
nix: use lib.fileset for src

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -3,7 +3,7 @@ on:
   - pull_request_target
 jobs:
   auto-merge-dependency-updates:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
       pull-requests: write

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,7 +7,7 @@
 rustPlatform.buildRustPackage {
   pname = "nixfmt-rs";
   version = "0.1.0";
-  src = ../.;
+  src = import ./source.nix { inherit lib; };
   cargoLock.lockFile = ../Cargo.lock;
   # The test suite shells out to the reference Haskell `nixfmt` to compare
   # output, so it must be on PATH during checkPhase.

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -1,0 +1,18 @@
+{ lib }:
+let
+  fs = lib.fileset;
+in
+fs.toSource {
+  root = ../.;
+  fileset = fs.unions [
+    ../Cargo.toml
+    ../Cargo.lock
+    ../src
+    ../benches
+    ../tests
+    # cargo workspace members; manifests must exist even when not built.
+    ../wasm
+    ../fuzz/Cargo.toml
+    ../fuzz/fuzz_targets
+  ];
+}

--- a/nix/wasm.nix
+++ b/nix/wasm.nix
@@ -10,7 +10,7 @@
 rustPlatform.buildRustPackage {
   pname = "nixfmt-wasm";
   version = "0.1.0";
-  src = ../.;
+  src = import ./source.nix { inherit lib; };
   cargoLock.lockFile = ../Cargo.lock;
 
   # cargoBuildHook hard-codes the host target via env+arg, so override


### PR DESCRIPTION

Keeps nix/, scripts/, web/, docs/, fuzz corpora etc. out of the store
path so editing them does not trigger a full cargo rebuild in CI.


