### PR TITLE
ci: publish to crates.io via Trusted Publishing on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Configure this environment on crates.io (Settings → Trusted Publishing)
+    # and optionally add protection rules in the GitHub repo settings.
+    environment: release
+    permissions:
+      contents: read
+      id-token: write # OIDC token exchange with crates.io
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify tag matches Cargo.toml version
+        if: github.event_name == 'release'
+        run: |
+          manifest=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "nixfmt_rs") | .version')
+          tag="${GITHUB_REF_NAME#v}"
+          if [ "$manifest" != "$tag" ]; then
+            echo "::error::Cargo.toml version ($manifest) does not match tag ($tag)"
+            exit 1
+          fi
+
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish
+        run: cargo publish -p nixfmt_rs --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION

bin/create-release.sh already cuts a draft release once the version-bump
PR lands; hook cargo publish onto the "published" event so flipping that
draft to public is the only manual step. Guard against shipping a tag
that disagrees with Cargo.toml.

Uses OIDC via rust-lang/crates-io-auth-action so no long-lived API token
secret is stored. The crate must be configured for Trusted Publishing on
crates.io (repo, workflow filename "publish.yml", environment "release")
after the initial manual publish.


