### PR TITLE
treefmt: format the repo with our own nixfmt build

### DIFF
--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -1,7 +1,12 @@
+{ pkgs, ... }:
 {
   projectRootFile = "flake.nix";
   programs = {
-    nixfmt.enable = true;
+    nixfmt = {
+      enable = true;
+      # Dogfood: format this repo with the binary built from this repo.
+      package = pkgs.callPackage ./package.nix { };
+    };
     rustfmt.enable = true;
   };
   settings.global.excludes = [


### PR DESCRIPTION

The whole point of byte-identical parity is that swapping the Haskell
binary for ours is a no-op; do that here so any divergence shows up
immediately as a formatting check failure rather than only in the
diff_sweep example.


