### PR TITLE
forbid(unsafe_code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ provides `hyperfine` and the script defaults to the nixpkgs revision
 pinned in `flake.lock`, so `nix develop -c scripts/bench.sh` is
 self-contained.
 
+For parser micro-benchmarks via criterion (the `bench` feature gates the
+criterion dependency so `cargo test` stays lean):
+
+```bash
+cargo bench --features bench
+```
+
 ## Design goals
 
 - **Exact behavioural parity.** `--ast`, `--ir` and formatted output are

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -417,8 +417,7 @@ impl Lexer {
     /// Remaining input from the cursor.
     #[inline]
     fn rest(&self) -> &str {
-        // `byte_pos` is always on a char boundary.
-        unsafe { self.source.get_unchecked(self.byte_pos..) }
+        &self.source[self.byte_pos..]
     }
 
     /// Peek at current byte without consuming (None at EOF).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 // Clippy pedantic/nursery are enabled workspace-wide via Cargo.toml [lints];
 // see the allow-list there for rationale.
 #![warn(missing_docs)]
+#![forbid(unsafe_code)]
 
 // Internal modules - hidden from public API
 mod colored_writer;


### PR DESCRIPTION

The single get_unchecked in the lexer was a premature optimisation:
hyperfine on all-packages.nix and maintainer-list.nix shows the safe
slice is within noise (1.00x / 1.01x). Drop it so the crate can
advertise no unsafe.
