### PR TITLE
release: attach attested static binaries and wasm to GitHub releases

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,0 +1,74 @@
+name: Release assets
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to attach assets to
+        required: true
+
+permissions:
+  contents: write
+  id-token: write # Sigstore OIDC for attestations
+  attestations: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            attr: packages.x86_64-linux.static
+            asset: nixfmt-x86_64-linux
+          - runner: ubuntu-24.04-arm
+            attr: packages.aarch64-linux.static
+            asset: nixfmt-aarch64-linux
+          - runner: macos-latest
+            attr: packages.aarch64-darwin.default
+            asset: nixfmt-aarch64-darwin
+          - runner: ubuntu-latest
+            attr: wasm
+            asset: nixfmt-wasm.tar.gz
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: NixOS/nix-installer-action@main
+      - name: Build
+        run: |
+          nix build -L .#${{ matrix.attr }}
+          if [ -d result/pkg ]; then
+            tar -C result -czf ${{ matrix.asset }} pkg
+          else
+            cp result/bin/nixfmt ${{ matrix.asset }}
+          fi
+          file ${{ matrix.asset }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: ${{ matrix.asset }}
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Checksums
+        run: |
+          cd dist
+          sha256sum nixfmt-* > SHA256SUMS
+          cat SHA256SUMS
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: dist/nixfmt-*
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: gh release upload -R "$GITHUB_REPOSITORY" "$TAG" dist/* --clobber

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ cargo install nixfmt_rs
 nix develop -c cargo build --release   # binary at target/release/nixfmt
 ```
 
+Prebuilt static binaries are attached to each
+[GitHub release](https://github.com/Mic92/nixfmt-rs/releases) with a
+`SHA256SUMS` file and Sigstore-backed provenance:
+
+```bash
+gh attestation verify ./nixfmt-x86_64-linux -R Mic92/nixfmt-rs
+```
+
 NixOS / home-manager (via flake input):
 
 ```nix

--- a/flake.nix
+++ b/flake.nix
@@ -26,10 +26,24 @@
       );
     in
     {
-      packages = forAllSystems (system: {
-        default = pkgsFor.${system}.callPackage ./nix/package.nix { };
-        wasm = pkgsFor.${system}.callPackage ./nix/wasm.nix { };
-      });
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor.${system};
+        in
+        {
+          default = pkgs.callPackage ./nix/package.nix { };
+          wasm = pkgs.callPackage ./nix/wasm.nix { };
+        }
+        // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          # Fully static musl binary for release artifacts.
+          static = pkgs.pkgsStatic.callPackage ./nix/package.nix {
+            # The reference Haskell nixfmt does not build under pkgsStatic;
+            # parity is already covered by the dynamic build's checkPhase.
+            nixfmt = null;
+          };
+        }
+      );
 
       devShells = forAllSystems (system: {
         default = pkgsFor.${system}.callPackage ./nix/shell.nix { };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -10,8 +10,10 @@ rustPlatform.buildRustPackage {
   src = import ./source.nix { inherit lib; };
   cargoLock.lockFile = ../Cargo.lock;
   # The test suite shells out to the reference Haskell `nixfmt` to compare
-  # output, so it must be on PATH during checkPhase.
-  nativeCheckInputs = [ nixfmt ];
+  # output, so it must be on PATH during checkPhase. Pass `nixfmt = null`
+  # (e.g. from pkgsStatic) to skip the suite where the reference can't build.
+  doCheck = nixfmt != null;
+  nativeCheckInputs = lib.optional (nixfmt != null) nixfmt;
   # The binary is named `nixfmt` (see Cargo.toml [[bin]]), not the pname.
   # Without this, lib.getExe guesses `nixfmt-rs` and treefmt-nix breaks.
   meta.mainProgram = "nixfmt";


### PR DESCRIPTION

Add a pkgsStatic musl build (Linux only) so the published binaries run
on any distro without a Nix store. The reference Haskell nixfmt does not
build under pkgsStatic, so allow passing nixfmt = null to skip the
diff-based checkPhase there; parity is still enforced by the dynamic
build.

Artifacts are gathered into a single job that writes SHA256SUMS and
generates SLSA provenance via actions/attest-build-provenance, so
downloads can be verified with `gh attestation verify`.


