### PR TITLE
create-release: survive self-modification by git pull

### DIFF
--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -45,9 +45,8 @@ if git tag -l | grep -q "^${version}\$"; then
   exit 1
 fi
 sed -i -e "0,/^version = \".*\"/s!^version = \".*\"!version = \"${version}\"!" Cargo.toml
-sed -i -e "s!version = \".*\";!version = \"${version}\";!" nix/package.nix
 cargo update --workspace # bump version in Cargo.lock
-git add Cargo.toml Cargo.lock nix/package.nix
+git add Cargo.toml Cargo.lock
 git branch -D "release-${version}" || true
 git checkout -b "release-${version}"
 git commit -m "bump version ${version}"

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# Brace group so bash reads the whole script before executing anything;
+# `git pull` below may rewrite this file mid-run otherwise.
+{
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd "$SCRIPT_DIR/.."
 
@@ -66,4 +70,7 @@ git checkout main
 
 waitForPr "release-${version}"
 git pull git@github.com:Mic92/nixfmt-rs main
-gh release create "${version}" --draft --title "${version}" --notes ""
+gh release create "${version}" --draft --title "${version}" --generate-notes
+
+exit 0
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,7 +6,7 @@
 }:
 rustPlatform.buildRustPackage {
   pname = "nixfmt-rs";
-  version = "0.1.2";
+  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).package.version;
   src = import ./source.nix { inherit lib; };
   cargoLock.lockFile = ../Cargo.lock;
   # The test suite shells out to the reference Haskell `nixfmt` to compare

--- a/nix/wasm.nix
+++ b/nix/wasm.nix
@@ -9,7 +9,7 @@
 }:
 rustPlatform.buildRustPackage {
   pname = "nixfmt-wasm";
-  version = "0.1.0";
+  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).package.version;
   src = import ./source.nix { inherit lib; };
   cargoLock.lockFile = ../Cargo.lock;
 


### PR DESCRIPTION

The script pulls main after the version-bump PR merges, which can change
this very file; bash then resumes reading at a stale byte offset and
executes garbage (observed: "0.1.2: command not found"). Wrap the body
in a brace group with a trailing exit so the whole file is parsed before
any of it runs. Also switch the draft release to --generate-notes.


