### PR TITLE
ci: bump actions to Node 24 compatible majors

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: NixOS/nix-installer-action@main
       - name: Build wasm package
@@ -35,7 +35,7 @@ jobs:
           # but disable Jekyll so files starting with `_` are kept as-is.
           touch site/.nojekyll
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -47,4 +47,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -45,7 +45,7 @@ jobs:
             cp result/bin/nixfmt ${{ matrix.asset }}
           fi
           file ${{ matrix.asset }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset }}
           path: ${{ matrix.asset }}
@@ -54,7 +54,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
@@ -64,7 +64,7 @@ jobs:
           sha256sum nixfmt-* > SHA256SUMS
           cat SHA256SUMS
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: dist/nixfmt-*
       - name: Upload to release


### PR DESCRIPTION

GitHub will force Node 24 on 2026-06-02 and drop Node 20 in September;
upload-artifact@v4 and friends already warn. Move to the current majors
across all workflows while at it.


