### PR TITLE
wasm: build an npm package and publish on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,3 +37,26 @@ jobs:
         run: cargo publish -p nixfmt_rs --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  npm:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write # npm provenance / trusted publishing
+    steps:
+      - uses: actions/checkout@v6
+      - uses: NixOS/nix-installer-action@main
+      - run: nix build -L .#wasm
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      - name: Publish
+        # Writable copy so npm can stage its tarball. Auth is tokenless via
+        # npm Trusted Publishing (OIDC); configure on npmjs.com after the
+        # initial manual `npm publish`.
+        run: |
+          cp -r result/npm dist
+          cd dist
+          npm publish --provenance --access public

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Build
         run: |
           nix build -L .#${{ matrix.attr }}
-          if [ -d result/pkg ]; then
-            tar -C result -czf ${{ matrix.asset }} pkg
+          if [ -d result/npm ]; then
+            tar -C result -czf ${{ matrix.asset }} npm
           else
             cp result/bin/nixfmt ${{ matrix.asset }}
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ dependencies = [
 name = "nixfmt-wasm"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "nixfmt_rs",
  "wasm-bindgen",
 ]

--- a/nix/wasm.nix
+++ b/nix/wasm.nix
@@ -6,10 +6,14 @@
   wasm-bindgen-cli,
   binaryen,
   lld,
+  jq,
 }:
+let
+  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).package.version;
+in
 rustPlatform.buildRustPackage {
   pname = "nixfmt-wasm";
-  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).package.version;
+  inherit version;
   src = import ./source.nix { inherit lib; };
   cargoLock.lockFile = ../Cargo.lock;
 
@@ -24,6 +28,7 @@ rustPlatform.buildRustPackage {
     wasm-bindgen-cli
     binaryen
     lld
+    jq
   ];
 
   buildPhase = ''
@@ -41,15 +46,25 @@ rustPlatform.buildRustPackage {
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/pkg
-    wasm-bindgen \
-      --target web \
-      --out-dir $out/pkg \
-      target/wasm32-unknown-unknown/release/nixfmt_wasm.wasm
-    wasm-opt -Oz \
-      $out/pkg/nixfmt_wasm_bg.wasm \
-      -o $out/pkg/nixfmt_wasm_bg.wasm.opt
-    mv $out/pkg/nixfmt_wasm_bg.wasm.opt $out/pkg/nixfmt_wasm_bg.wasm
+    raw=target/wasm32-unknown-unknown/release/nixfmt_wasm.wasm
+
+    # Playground (kept at $out/pkg for backwards compat with gh-pages.yml).
+    wasm-bindgen --target web --out-dir $out/pkg $raw
+    wasm-opt -Oz $out/pkg/nixfmt_wasm_bg.wasm -o $out/pkg/nixfmt_wasm_bg.wasm
+
+    # npm package: bundler + node + web entry points under one package.json.
+    npm=$out/npm
+    for t in bundler nodejs web; do
+      dir=$npm/''${t/nodejs/node}
+      wasm-bindgen --target $t --out-dir $dir $raw
+      wasm-opt -Oz $dir/nixfmt_wasm_bg.wasm -o $dir/nixfmt_wasm_bg.wasm
+    done
+    # node/ is CommonJS; override the package-level "type":"module".
+    echo '{"type":"commonjs"}' > $npm/node/package.json
+    jq '.version = "${version}"' ${../wasm/package.json} > $npm/package.json
+    cp ${../wasm/README.md} $npm/README.md
+    cp ${../LICENSE} $npm/LICENSE
+
     runHook postInstall
   '';
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,10 @@ mod pretty;
 mod types;
 
 pub use error::ParseError;
+
+/// Version of the `nixfmt_rs` crate (and thus the formatting rules).
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 use predoc::{Pretty, RenderConfig, render_with_config};
 
 // Internal-only Result type and AST types

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::process::exit;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+use nixfmt_rs::VERSION;
 
 const HELP: &str = "\
 nixfmt-rs [OPTIONS] [FILES]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,3 +15,4 @@ nixfmt_rs = { path = "..", default-features = false }
 # Pinned: wasm-bindgen schema must match the wasm-bindgen-cli shipped by
 # nixpkgs exactly. Bump in lockstep with the CLI version there.
 wasm-bindgen = "=0.2.117"
+js-sys = "0.3"

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,0 +1,31 @@
+# nixfmt-rs (WebAssembly)
+
+Format Nix code from JavaScript/TypeScript. Same output as
+[`nixfmt`](https://github.com/NixOS/nixfmt), byte-for-byte.
+
+```sh
+npm install nixfmt-rs
+```
+
+## Node / bundlers
+
+```ts
+import { format, version } from "nixfmt-rs";
+
+format("{a=1;}");                          // "{ a = 1; }\n"
+format(src, { width: 80, indent: 2, filename: "default.nix" });
+version();                                 // "0.1.2"
+```
+
+Parse failures throw a `ParseError` with `message` (one line),
+`diagnostic` (rendered snippet) and `range: [start, end]` byte offsets.
+
+## Browser (no bundler)
+
+```js
+import init, { format } from "nixfmt-rs/web";
+await init();
+format("{a=1;}");
+```
+
+See <https://mic92.github.io/nixfmt-rs/> for a live playground.

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "nixfmt-rs",
+  "version": "0.0.0",
+  "description": "WebAssembly build of nixfmt-rs — drop-in nixfmt with byte-identical output",
+  "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mic92/nixfmt-rs.git"
+  },
+  "keywords": ["nix", "formatter", "nixfmt", "wasm"],
+  "type": "module",
+  "files": ["bundler", "node", "web", "README.md"],
+  "main": "./node/nixfmt_wasm.js",
+  "module": "./bundler/nixfmt_wasm.js",
+  "types": "./bundler/nixfmt_wasm.d.ts",
+  "exports": {
+    ".": {
+      "types": "./bundler/nixfmt_wasm.d.ts",
+      "node": "./node/nixfmt_wasm.js",
+      "default": "./bundler/nixfmt_wasm.js"
+    },
+    "./web": {
+      "types": "./web/nixfmt_wasm.d.ts",
+      "default": "./web/nixfmt_wasm.js"
+    }
+  },
+  "sideEffects": ["./bundler/nixfmt_wasm.js", "./node/nixfmt_wasm.js"]
+}

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,58 +1,78 @@
 //! WebAssembly bindings for `nixfmt-rs`.
 //!
-//! Build via `nix build .#wasm`, or manually:
-//!
-//! ```sh
-//! cargo build -p nixfmt-wasm --release --target wasm32-unknown-unknown
-//! wasm-bindgen --target web --out-dir pkg \
-//!     target/wasm32-unknown-unknown/release/nixfmt_wasm.wasm
+//! ```js
+//! import init, { format, version } from "nixfmt-wasm";
+//! await init();
+//! format("{a=1;}");                    // "{ a = 1; }\n"
+//! format(src, { width: 80, indent: 4, filename: "foo.nix" });
 //! ```
 
+use js_sys::{Array, Error, Reflect};
 use wasm_bindgen::prelude::*;
 
-/// Format a Nix expression with default layout (width 100, indent 2).
-///
-/// # Errors
-/// Throws a JS exception whose message is the same multi-line diagnostic
-/// the CLI prints (snippet + caret + hint). ANSI escapes are stripped
-/// since browser DOM nodes don't render them.
-#[wasm_bindgen]
-pub fn format(source: &str) -> Result<String, JsError> {
-    format_with(source, 100, 2)
+#[wasm_bindgen(typescript_custom_section)]
+const TS: &str = r#"
+export interface FormatOptions {
+  /** Target line width (soft). Default 100. */
+  width?: number;
+  /** Spaces per indentation level. Default 2. */
+  indent?: number;
+  /** Name shown in the diagnostic on parse failure. */
+  filename?: string;
 }
 
-/// Format a Nix expression with explicit `width` (line width) and `indent`
-/// (spaces per level).
-///
-/// # Errors
-/// See [`format`].
+/** Thrown by {@link format} when `source` is not valid Nix. */
+export interface ParseError extends Error {
+  /** Multi-line rustc-style diagnostic with source snippet and caret. */
+  diagnostic: string;
+  /** Byte offsets `[start, end)` of the primary error span in `source`. */
+  range: [number, number];
+}
+"#;
+
 #[wasm_bindgen]
-pub fn format_with(source: &str, width: usize, indent: usize) -> Result<String, JsError> {
+extern "C" {
+    #[wasm_bindgen(typescript_type = "FormatOptions")]
+    pub type FormatOptions;
+    #[wasm_bindgen(method, getter, structural)]
+    fn width(this: &FormatOptions) -> Option<u32>;
+    #[wasm_bindgen(method, getter, structural)]
+    fn indent(this: &FormatOptions) -> Option<u32>;
+    #[wasm_bindgen(method, getter, structural)]
+    fn filename(this: &FormatOptions) -> Option<String>;
+}
+
+/// Format a Nix expression. Throws {@link ParseError} if `source` is invalid.
+#[wasm_bindgen(unchecked_return_type = "string")]
+pub fn format(source: &str, options: Option<FormatOptions>) -> Result<String, JsValue> {
     let mut opts = nixfmt_rs::Options::default();
-    opts.width = width;
-    opts.indent = indent;
+    let mut filename = None;
+    if let Some(o) = options.as_ref() {
+        if let Some(w) = o.width() {
+            opts.width = w as usize;
+        }
+        if let Some(i) = o.indent() {
+            opts.indent = i as usize;
+        }
+        filename = o.filename();
+    }
+
     nixfmt_rs::format_with(source, &opts).map_err(|e| {
-        let pretty = nixfmt_rs::format_error(source, None, &e);
-        JsError::new(&strip_ansi(&pretty))
+        let r = e.byte_range();
+        let diagnostic = nixfmt_rs::format_error(source, filename.as_deref(), &e);
+        let err = Error::new(&e.message());
+        err.set_name("ParseError");
+        let obj: &JsValue = err.as_ref();
+        let _ = Reflect::set(obj, &"diagnostic".into(), &diagnostic.into());
+        let range = Array::of2(&(r.start as u32).into(), &(r.end as u32).into());
+        let _ = Reflect::set(obj, &"range".into(), &range);
+        err.into()
     })
 }
 
-/// Drop ANSI SGR escape sequences (`\x1b[...m`). The CLI formatter colours
-/// its output for terminals; the playground renders plain text in a `<pre>`.
-fn strip_ansi(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '\x1b' && chars.peek() == Some(&'[') {
-            chars.next();
-            for term in chars.by_ref() {
-                if term.is_ascii_alphabetic() {
-                    break;
-                }
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    out
+/// Crate version string, e.g. `"0.1.2"`.
+#[wasm_bindgen]
+#[must_use]
+pub fn version() -> String {
+    nixfmt_rs::VERSION.into()
 }

--- a/web/index.html
+++ b/web/index.html
@@ -262,7 +262,7 @@
     </main>
 
     <script type="module">
-      import init, { format_with } from "./pkg/nixfmt_wasm.js";
+      import init, { format } from "./pkg/nixfmt_wasm.js";
 
       const $ = (id) => document.getElementById(id);
       const input = $("input");
@@ -282,13 +282,13 @@
         const indent = Math.max(0, +indentEl.value || 2);
         const t0 = performance.now();
         try {
-          output.textContent = format_with(input.value, width, indent);
+          output.textContent = format(input.value, { width, indent });
           output.classList.remove("error");
           const dt = (performance.now() - t0).toFixed(2);
           const bytes = new TextEncoder().encode(input.value).length;
           setStatus(`formatted ${bytes} B in ${dt} ms`, "ready");
         } catch (e) {
-          output.textContent = String(e.message ?? e);
+          output.textContent = e.diagnostic ?? String(e.message ?? e);
           output.classList.add("error");
           setStatus("parse error", "error");
         }


### PR DESCRIPTION

Emit bundler/node/web wasm-bindgen targets into a single npm package
with conditional exports, so `import { format } from "nixfmt-rs"` works
under bundlers and Node alike while `nixfmt-rs/web` keeps the explicit
init() for script-tag use. The version is injected from Cargo.toml at
build time so the release script needs no extra bookkeeping.

Publish from the same release-triggered workflow as crates.io, with npm
provenance via OIDC. The first upload still needs an NPM_TOKEN secret;
once the package exists, configure Trusted Publishing on npmjs.com and
the secret can be dropped. The release-assets tarball now ships the npm
layout instead of the bare web pkg.


