### PR TITLE
cli: accept '-' as stdin, warn on bare invocation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use nixfmt_rs::VERSION;
 
 const HELP: &str = "\
-nixfmt-rs [OPTIONS] [FILES]
+nixfmt-rs [OPTIONS] [FILES or -]
   Format Nix source code (Rust implementation of nixfmt)
+  Use '-' as a file argument to read from stdin.
 
 Common flags:
   -w --width=INT        Maximum width in characters [default: 100]
@@ -108,6 +109,7 @@ fn parse_args() -> Result<Opts, String> {
                     .parse()
                     .map_err(|_| "Invalid integer for --width".to_string())?;
             }
+            "-" => o.files.push("-".to_string()),
             s if s.starts_with('-') => return Err(format!("Unknown flag: {s}")),
             _ => o.files.push(arg),
         }
@@ -210,7 +212,13 @@ fn main() {
 
     let mut ok = true;
 
-    if o.files.is_empty() {
+    let stdin_only = o.files.is_empty() || o.files.iter().all(|f| f == "-");
+    if o.files.is_empty() && !o.quiet {
+        eprintln!(
+            "Warning: Bare invocation of nixfmt-rs is deprecated. Use 'nixfmt-rs -' for anonymous stdin."
+        );
+    }
+    if stdin_only {
         let mut buf = String::new();
         if let Err(e) = io::stdin().read_to_string(&mut buf) {
             eprintln!("error: failed to read stdin: {e}");
@@ -218,6 +226,9 @@ fn main() {
         }
         let name = o.filename.as_deref().unwrap_or("<stdin>");
         ok &= process(&o, name, &buf, false);
+    } else if o.files.iter().any(|f| f == "-") {
+        eprintln!("error: cannot mix '-' (stdin) with file arguments");
+        exit(1);
     } else {
         // Debug dumps stream to stderr; running them in parallel would
         // interleave output, so keep those modes sequential.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -52,11 +52,27 @@ fn stdin_formats_to_stdout() {
     let out = ours(&[], Some(UNFORMATTED));
     assert!(out.status.success());
     assert_eq!(String::from_utf8_lossy(&out.stdout), FORMATTED);
-    assert!(out.stderr.is_empty());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Bare invocation"),
+        "expected deprecation warning, got stderr={stderr:?}"
+    );
 
     let ref_out = nixfmt(&[], Some(UNFORMATTED));
     assert_eq!(out.stdout, ref_out.stdout);
     assert_eq!(out.status.code(), ref_out.status.code());
+}
+
+#[test]
+fn dash_reads_stdin_without_warning() {
+    let out = ours(&["-"], Some(UNFORMATTED));
+    assert!(out.status.success(), "stderr={:?}", out.stderr);
+    assert_eq!(String::from_utf8_lossy(&out.stdout), FORMATTED);
+    assert!(
+        out.stderr.is_empty(),
+        "no warning when '-' is explicit, got {:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
 }
 
 #[test]
@@ -75,12 +91,12 @@ fn check_unformatted_stdin_exits_1() {
 
 #[test]
 fn check_formatted_stdin_exits_0() {
-    let out = ours(&["--check"], Some(FORMATTED));
+    let out = ours(&["--check", "-"], Some(FORMATTED));
     assert_eq!(out.status.code(), Some(0));
     assert!(out.stdout.is_empty());
     assert!(out.stderr.is_empty());
 
-    let ref_out = nixfmt(&["--check"], Some(FORMATTED));
+    let ref_out = nixfmt(&["--check", "-"], Some(FORMATTED));
     assert_eq!(ref_out.status.code(), Some(0));
 }
 


### PR DESCRIPTION

Match upstream nixfmt (NixOS/nixfmt#376): '-' means read stdin; bare
invocation still works but prints a deprecation warning (suppressed by
--quiet). Mixing '-' with file paths is rejected.

Closes #54
