### PR TITLE
add json output to help with lsps

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,31 @@ Error[E005]: commas are not used to separate list elements in Nix
 Run `cargo run --example error_visualization` to see the full catalogue
 of diagnostics on intentionally broken inputs.
 
+### Machine-readable output
+
+For editor / LSP integrations, `--message-format=json` writes one JSON
+object per diagnostic to stderr instead of the rendered snippet. The shape
+follows the LSP `Diagnostic` type (0-based `range`), with raw `byteRange`
+offsets and the human `rendered` text alongside:
+
+```console
+$ nixfmt --message-format=json --check . 2>&1 >/dev/null | jq -c .
+{"file":"config.nix","severity":"error","code":"E002",
+ "message":"unclosed delimiter '{'",
+ "range":{"start":{"line":4,"character":0},"end":{"line":4,"character":0}},
+ "byteRange":{"start":42,"end":42},
+ "help":"add closing '}'",
+ "relatedInformation":[{"message":"unclosed delimiter opened here",
+   "range":{"start":{"line":2,"character":8},"end":{"line":2,"character":9}},
+   "byteRange":{"start":18,"end":19}}],
+ "rendered":"Error[E002]: unclosed delimiter '{'\n   ┌─ config.nix:5:1\n..."}
+{"file":"ok.nix","severity":"warning","message":"not formatted"}
+```
+
+In this mode every line on stderr is JSON (parse errors, `--check`
+results, I/O failures), so wrappers can parse line-by-line without
+special-casing.
+
 ## Benchmarks
 
 `--check` over a full nixpkgs checkout (42 942 `.nix` files), AMD EPYC

--- a/docs/nixfmt.1.scd
+++ b/docs/nixfmt.1.scd
@@ -63,6 +63,19 @@ explicit.
 	Filename to use in diagnostic messages when input is read from standard
 	input. Useful for editor integrations.
 
+*--message-format*=_FMT_
+	How diagnostics are rendered on standard error. _FMT_ is one of:
+
+	*human* (default)
+		rustc-style snippets with carets and fix-it hints.
+
+	*json*
+		One JSON object per line, shaped like an LSP _Diagnostic_: _file_,
+		_severity_, _code_, _message_, 0-based _range_, _byteRange_, optional
+		_help_ and _relatedInformation_, plus the human _rendered_ text. All
+		standard-error output (including *--check* results and I/O errors) is
+		JSON in this mode.
+
 *-?*, *--help*
 	Display a short help message and exit.
 
@@ -101,6 +114,10 @@ Check formatting in CI without modifying files:
 Format a snippet from a pipeline:
 
 	*echo '{a=1;}' | nixfmt -*
+
+Consume diagnostics from a wrapper or LSP:
+
+	*nixfmt --message-format=json --check . 2>&1 >/dev/null | jq .*
 
 Use as a *git mergetool*:
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,6 +105,44 @@ impl ParseError {
         self.span.start as usize..self.span.end as usize
     }
 
+    /// Short, actionable fix suggestion if one is known.
+    ///
+    /// Intended for editor integrations that want a one-line hint (e.g. an
+    /// LSP code-action title) without parsing the rendered snippet.
+    #[must_use]
+    pub fn help(&self) -> Option<String> {
+        match &self.kind {
+            ErrorKind::InvalidSyntax { hint, .. } => hint.clone(),
+            ErrorKind::UnclosedDelimiter { delimiter, .. } => {
+                let (_, close) = format::ErrorFormatter::delimiter_pair(*delimiter);
+                Some(format!("add closing {close}"))
+            }
+            ErrorKind::ChainedComparison { .. } => {
+                Some("use parentheses: (a < b) && (b < c)".to_string())
+            }
+            ErrorKind::MissingToken { token, .. } => Some(format!("add {token}")),
+            ErrorKind::UnexpectedToken { expected, found } => match expected.as_slice() {
+                [single] => {
+                    format::unexpected_token_hint(single, found).map(|(_, help)| help.to_string())
+                }
+                _ => None,
+            },
+        }
+    }
+
+    /// Secondary locations worth pointing at alongside the primary span,
+    /// as `(byte_range, label)` pairs (e.g. the unmatched opening delimiter).
+    #[must_use]
+    pub fn related(&self) -> Vec<(std::ops::Range<usize>, String)> {
+        match &self.kind {
+            ErrorKind::UnclosedDelimiter { opening_span, .. } => vec![(
+                opening_span.start as usize..opening_span.end as usize,
+                "unclosed delimiter opened here".to_string(),
+            )],
+            _ => Vec::new(),
+        }
+    }
+
     /// Get error code if available
     #[must_use]
     pub const fn code(&self) -> Option<&str> {

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -193,7 +193,10 @@ fn visual_span(line_text: &str, line_start: usize, span: Span) -> (usize, usize)
 ///
 /// Keyed on the *expected* token; `found` lets us special-case a few
 /// confusable pairs without guessing about parser context we don't have here.
-fn unexpected_token_hint(expected: &str, found: &str) -> Option<(&'static str, &'static str)> {
+pub(super) fn unexpected_token_hint(
+    expected: &str,
+    found: &str,
+) -> Option<(&'static str, &'static str)> {
     Some(match expected {
         "';'" => (
             "missing semicolon after definition",
@@ -232,7 +235,7 @@ fn unexpected_token_hint(expected: &str, found: &str) -> Option<(&'static str, &
 impl ErrorFormatter<'_> {
     /// The lexer encodes the `''` opener as a single `'`; expand it back so we
     /// don't render `'''`.
-    const fn delimiter_pair(opening: char) -> (&'static str, &'static str) {
+    pub(super) const fn delimiter_pair(opening: char) -> (&'static str, &'static str) {
         match opening {
             '{' => ("'{'", "'}'"),
             '[' => ("'['", "']'"),

--- a/src/json_diag.rs
+++ b/src/json_diag.rs
@@ -1,0 +1,231 @@
+//! `--message-format=json` rendering for the CLI.
+//!
+//! One JSON object per line on stderr. Shape mirrors an LSP `Diagnostic` so a
+//! thin wrapper (or nil/nixd shelling out) can forward it directly:
+//!
+//! ```text
+//! {
+//!   "file": "default.nix",
+//!   "severity": "error",
+//!   "code": "E002",
+//!   "message": "unclosed delimiter '{'",
+//!   "range": {"start":{"line":0,"character":0},"end":{"line":0,"character":1}},
+//!   "byteRange": {"start":0,"end":1},
+//!   "help": "add closing '}'",
+//!   "relatedInformation": [{"message":"...","range":{...},"byteRange":{...}}],
+//!   "rendered": "Error[E002]: ...\n..."
+//! }
+//! ```
+//!
+//! `range` is 0-based line / character (Unicode scalars from line start);
+//! `byteRange` gives raw byte offsets for consumers that need exact addressing.
+
+use std::fmt::Write;
+use std::ops::Range;
+
+use nixfmt_rs::ParseError;
+
+pub fn parse_error(source: &str, file: &str, error: &ParseError) -> String {
+    let lines = LineIndex::new(source);
+    let mut o = Obj::new();
+
+    o.str("file", file);
+    o.str("severity", "error");
+    if let Some(code) = error.code() {
+        o.str("code", code);
+    }
+    o.str("message", &error.message());
+
+    let span = error.byte_range();
+    o.raw("range", &lines.range(&span));
+    o.raw("byteRange", &byte_range(&span));
+
+    if let Some(help) = error.help() {
+        o.str("help", &help);
+    }
+
+    let related = error.related();
+    if !related.is_empty() {
+        let mut arr = String::from("[");
+        for (i, (span, msg)) in related.iter().enumerate() {
+            if i > 0 {
+                arr.push(',');
+            }
+            let mut r = Obj::new();
+            r.str("message", msg);
+            r.raw("range", &lines.range(span));
+            r.raw("byteRange", &byte_range(span));
+            arr.push_str(&r.finish());
+        }
+        arr.push(']');
+        o.raw("relatedInformation", &arr);
+    }
+
+    o.str(
+        "rendered",
+        &nixfmt_rs::format_error(source, Some(file), error),
+    );
+    o.finish()
+}
+
+pub fn message(file: Option<&str>, severity: &str, msg: &str) -> String {
+    let mut o = Obj::new();
+    if let Some(f) = file {
+        o.str("file", f);
+    }
+    o.str("severity", severity);
+    o.str("message", msg);
+    o.finish()
+}
+
+/// Byte → (0-based line, 0-based char column) lookup.
+struct LineIndex<'a> {
+    source: &'a str,
+    starts: Vec<usize>,
+}
+
+impl<'a> LineIndex<'a> {
+    fn new(source: &'a str) -> Self {
+        let starts = std::iter::once(0)
+            .chain(source.match_indices('\n').map(|(i, _)| i + 1))
+            .collect();
+        Self { source, starts }
+    }
+
+    fn position(&self, offset: usize) -> (usize, usize) {
+        let offset = offset.min(self.source.len());
+        let line = match self.starts.binary_search(&offset) {
+            Ok(i) => i,
+            Err(i) => i.saturating_sub(1),
+        };
+        let start = self.starts[line];
+        let col = self.source[start..offset].chars().count();
+        (line, col)
+    }
+}
+
+impl LineIndex<'_> {
+    fn range(&self, span: &Range<usize>) -> String {
+        let (sl, sc) = self.position(span.start);
+        let (el, ec) = self.position(span.end);
+        format!(
+            "{{\"start\":{{\"line\":{sl},\"character\":{sc}}},\
+             \"end\":{{\"line\":{el},\"character\":{ec}}}}}"
+        )
+    }
+}
+
+fn byte_range(span: &Range<usize>) -> String {
+    format!("{{\"start\":{},\"end\":{}}}", span.start, span.end)
+}
+
+/// Tiny JSON object builder; avoids a `serde` dep for a debug stream.
+struct Obj {
+    buf: String,
+}
+
+impl Obj {
+    fn new() -> Self {
+        Self {
+            buf: String::from("{"),
+        }
+    }
+    fn key(&mut self, k: &str) {
+        if self.buf.len() > 1 {
+            self.buf.push(',');
+        }
+        self.buf.push('"');
+        self.buf.push_str(k);
+        self.buf.push_str("\":");
+    }
+    fn str(&mut self, k: &str, v: &str) {
+        self.key(k);
+        push_json_str(&mut self.buf, v);
+    }
+    fn raw(&mut self, k: &str, v: &str) {
+        self.key(k);
+        self.buf.push_str(v);
+    }
+    fn finish(mut self) -> String {
+        self.buf.push('}');
+        self.buf
+    }
+}
+
+fn push_json_str(out: &mut String, s: &str) {
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => write!(out, "\\u{:04x}", c as u32).unwrap(),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(src: &str, name: &str) -> String {
+        let err = nixfmt_rs::parse(src).unwrap_err();
+        parse_error(src, name, &err)
+    }
+
+    #[test]
+    fn unclosed_brace_has_related_and_help() {
+        let json = render("{\n  x = 1;\n", "t.nix");
+        assert!(json.starts_with('{') && json.ends_with('}'));
+        assert!(json.contains(r#""file":"t.nix""#), "{json}");
+        assert!(json.contains(r#""code":"E002""#), "{json}");
+        assert!(json.contains(r#""help":"add closing '}'""#), "{json}");
+        assert!(json.contains(r#""relatedInformation":["#), "{json}");
+        assert!(json.contains(r#""start":{"line":2"#), "{json}");
+        assert!(
+            json.contains(r#""byteRange":{"start":0,"end":1}"#),
+            "{json}"
+        );
+    }
+
+    #[test]
+    fn unexpected_token_carries_help() {
+        let json = render("let x = 1\ny = 2; in x", "t.nix");
+        assert!(json.contains(r#""code":"E001""#), "{json}");
+        assert!(
+            json.contains(r#""help":"add a semicolon at the end of the previous line""#),
+            "{json}"
+        );
+    }
+
+    #[test]
+    fn rendered_field_is_escaped_single_line() {
+        let json = render("(1 + 2", "t.nix");
+        assert!(json.contains(r#""rendered":""#));
+        assert!(json.contains("\\n"), "{json}");
+        assert!(!json.contains('\n'), "{json}");
+    }
+
+    #[test]
+    fn json_escaping_handles_quotes_and_controls() {
+        let mut s = String::new();
+        push_json_str(&mut s, "a\"b\\c\n\u{1}");
+        assert_eq!(s, r#""a\"b\\c\n\u0001""#);
+    }
+
+    #[test]
+    fn message_only_object_is_minimal() {
+        assert_eq!(
+            message(Some("a.nix"), "warning", "not formatted"),
+            r#"{"file":"a.nix","severity":"warning","message":"not formatted"}"#
+        );
+        assert_eq!(
+            message(None, "error", "boom"),
+            r#"{"severity":"error","message":"boom"}"#
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use nixfmt_rs::VERSION;
 
+mod json_diag;
+
 const HELP: &str = "\
 nixfmt-rs [OPTIONS] [FILES or -]
   Format Nix source code (Rust implementation of nixfmt)
@@ -30,6 +32,9 @@ Common flags:
   -a --ast              Pretty print the internal AST to stderr (debug)
   -f --filename=ITEM    Filename to display when input is read from stdin
      --ir               Pretty print the internal IR to stderr (debug)
+     --message-format=FMT
+                        How to render diagnostics: 'human' (default) or 'json'
+                        (one JSON object per line on stderr, LSP Diagnostic shape)
   -? --help             Display help message
   -V --version          Print version information
      --numeric-version  Print just the version number
@@ -49,6 +54,7 @@ struct Opts {
     ir: bool,
     parse_only: bool,
     mergetool: bool,
+    json_diagnostics: bool,
     filename: Option<String>,
     files: Vec<String>,
 }
@@ -100,6 +106,14 @@ fn parse_args() -> Result<Opts, String> {
             "--ir" => o.ir = true,
             "--parse-only" => o.parse_only = true,
             "-m" | "--mergetool" => o.mergetool = true,
+            "--message-format" => {
+                let v = value("--message-format")?;
+                o.json_diagnostics = match v.as_str() {
+                    "human" => false,
+                    "json" => true,
+                    other => return Err(format!("Unknown --message-format: {other}")),
+                };
+            }
             "-f" | "--filename" => o.filename = Some(value("--filename")?),
             "--" => {
                 o.files.extend(args.by_ref());
@@ -117,21 +131,48 @@ fn parse_args() -> Result<Opts, String> {
     Ok(o)
 }
 
+fn render_err(o: &Opts, source: &str, name: &str, e: &nixfmt_rs::ParseError) -> String {
+    if o.json_diagnostics {
+        json_diag::parse_error(source, name, e)
+    } else {
+        nixfmt_rs::format_error(source, Some(name), e)
+    }
+}
+
+fn report(o: &Opts, file: Option<&str>, severity: &str, msg: &str) {
+    eprintln!("{}", render_msg(o, file, severity, msg));
+}
+
 fn try_format(o: &Opts, name: &str, source: &str) -> Result<String, String> {
     let fmt = |s: &str| {
         let mut opts = nixfmt_rs::Options::default();
         opts.width = o.width;
         opts.indent = o.indent;
-        nixfmt_rs::format_with(s, &opts).map_err(|e| nixfmt_rs::format_error(s, Some(name), &e))
+        nixfmt_rs::format_with(s, &opts).map_err(|e| render_err(o, s, name, &e))
     };
     let out = fmt(source)?;
     if o.verify {
-        let again = fmt(&out).map_err(|e| format!("{name}: nixfmt verify: reparse failed\n{e}"))?;
+        let again = fmt(&out)?;
         if again != out {
-            return Err(format!("{name}: nixfmt verify: output is not idempotent"));
+            return Err(render_msg(
+                o,
+                Some(name),
+                "error",
+                "verify: output is not idempotent",
+            ));
         }
     }
     Ok(out)
+}
+
+fn render_msg(o: &Opts, file: Option<&str>, severity: &str, msg: &str) -> String {
+    if o.json_diagnostics {
+        json_diag::message(file, severity, msg)
+    } else if let Some(f) = file {
+        format!("{f}: {msg}")
+    } else {
+        msg.to_string()
+    }
 }
 
 /// Returns `true` on success so the caller can fold exit status across files.
@@ -141,7 +182,7 @@ fn process(o: &Opts, name: &str, source: &str, in_place: bool) -> bool {
             Ok(_) => true,
             Err(e) => {
                 if !o.quiet {
-                    eprintln!("{}", nixfmt_rs::format_error(source, Some(name), &e));
+                    eprintln!("{}", render_err(o, source, name, &e));
                 }
                 false
             }
@@ -158,7 +199,7 @@ fn process(o: &Opts, name: &str, source: &str, in_place: bool) -> bool {
         match res {
             Ok(s) => eprint!("{s}"),
             Err(e) if !o.quiet => {
-                eprintln!("{}", nixfmt_rs::format_error(source, Some(name), &e));
+                eprintln!("{}", render_err(o, source, name, &e));
             }
             Err(_) => {}
         }
@@ -178,7 +219,7 @@ fn process(o: &Opts, name: &str, source: &str, in_place: bool) -> bool {
     if o.check {
         if out != source {
             if !o.quiet {
-                eprintln!("{name}: not formatted");
+                report(o, Some(name), "warning", "not formatted");
             }
             return false;
         }
@@ -191,7 +232,7 @@ fn process(o: &Opts, name: &str, source: &str, in_place: bool) -> bool {
             && let Err(e) = std::fs::write(name, &out)
         {
             if !o.quiet {
-                eprintln!("{name}: {e}");
+                report(o, Some(name), "error", &e.to_string());
             }
             return false;
         }
@@ -217,7 +258,7 @@ fn main() {
     }
 
     let stdin_only = o.files.is_empty() || o.files.iter().all(|f| f == "-");
-    if o.files.is_empty() && !o.quiet {
+    if o.files.is_empty() && !o.quiet && !o.json_diagnostics {
         eprintln!(
             "Warning: Bare invocation of nixfmt-rs is deprecated. Use 'nixfmt-rs -' for anonymous stdin."
         );
@@ -249,7 +290,7 @@ fn process_path(o: &Opts, path: &Path) -> bool {
         Ok(source) => process(o, &name, &source, true),
         Err(e) => {
             if !o.quiet {
-                eprintln!("{name}: {e}");
+                report(o, Some(&name), "error", &e.to_string());
             }
             false
         }
@@ -281,7 +322,7 @@ fn walk_and_process(o: &Opts, parallel: bool) -> bool {
             Ok(_) => true,
             Err(e) => {
                 if !o.quiet {
-                    eprintln!("{e}");
+                    report(o, None, "error", &e.to_string());
                 }
                 false
             }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -48,6 +48,65 @@ const FORMATTED: &str = "{ a = 1; }\n";
 const INVALID: &str = "{a=1;\n";
 
 #[test]
+fn message_format_json_emits_one_object_per_error() {
+    let out = ours(
+        &["--message-format=json", "-f", "bad.nix", "-"],
+        Some(INVALID),
+    );
+    assert_eq!(out.status.code(), Some(1));
+    assert!(out.stdout.is_empty(), "no formatted output on parse error");
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    // Schema details covered by json_diag unit tests; here we only check the
+    // flag is wired and -f reaches the output.
+    let line = stderr.lines().next().expect("one json line");
+    assert!(line.starts_with('{') && line.ends_with('}'), "{line}");
+    assert!(line.contains(r#""file":"bad.nix""#), "{line}");
+}
+
+#[test]
+fn message_format_json_check_mode_is_pure_json() {
+    let d = tempfile::tempdir().unwrap();
+    let f = tmpfile(&d, "a.nix", UNFORMATTED);
+    let out = ours(
+        &["--message-format=json", "--check", f.to_str().unwrap()],
+        None,
+    );
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    for line in stderr.lines() {
+        assert!(
+            line.starts_with('{') && line.ends_with('}'),
+            "non-JSON on stderr: {line:?}"
+        );
+    }
+    assert!(stderr.contains(r#""message":"not formatted""#), "{stderr}");
+    assert!(stderr.contains(r#""severity":"warning""#), "{stderr}");
+}
+
+#[test]
+fn message_format_json_io_error_is_json() {
+    let out = ours(&["--message-format=json", "/nonexistent/path.nix"], None);
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(!stderr.is_empty());
+    for line in stderr.lines() {
+        assert!(line.starts_with('{') && line.ends_with('}'), "{line:?}");
+    }
+    // Walker reports the missing path inside its error message; we only
+    // guarantee the line is valid JSON, not that `file` is split out.
+    assert!(stderr.contains("/nonexistent/path.nix"), "{stderr}");
+    assert!(stderr.contains(r#""severity":"error""#), "{stderr}");
+}
+
+#[test]
+fn message_format_rejects_unknown_value() {
+    let out = ours(&["--message-format=xml", "-"], Some(UNFORMATTED));
+    assert_eq!(out.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("--message-format"), "{stderr}");
+}
+
+#[test]
 fn stdin_formats_to_stdout() {
     let out = ours(&[], Some(UNFORMATTED));
     assert!(out.status.success());


### PR DESCRIPTION
Adds `--message-format=json`: one LSP-shaped JSON object per diagnostic on
stderr (parse errors, `--check` results, I/O failures), so editor wrappers
can consume nixfmt without scraping the human-rendered snippet.

Also exposes `ParseError::help()` / `ParseError::related()` on the library
side so embedders (nil, nixd) can build their own `lsp_types::Diagnostic`
from the same data.

### Neovim demo

<img width="3120" height="1232" alt="nixfmt-nvim-demo" src="https://github.com/user-attachments/assets/304b95b2-58ad-41f3-865e-b7b7dd310517" />

Produced with stock `vim.diagnostic` — no LSP server, no plugins:

<details>
<summary><code>init.lua</code> (~60 lines)</summary>

```lua
vim.o.number = true
vim.o.signcolumn = 'yes'
vim.diagnostic.config({
  virtual_text = { prefix = '■', source = true },
  float = { border = 'rounded', source = true, header = '' },
  severity_sort = true,
})

local ns = vim.api.nvim_create_namespace('nixfmt')
local sev = { error = vim.diagnostic.severity.ERROR, warning = vim.diagnostic.severity.WARN }

local function publish(buf)
  local file = vim.api.nvim_buf_get_name(buf)
  local r = vim.system({
    'nixfmt', '--message-format=json', '--check', file,
  }, { text = true }):wait()
  local diags = {}
  for line in (r.stderr or ''):gmatch('[^\n]+') do
    local ok, d = pcall(vim.json.decode, line)
    if ok and d.range then
      local item = {
        lnum = d.range.start.line, col = d.range.start.character,
        end_lnum = d.range['end'].line, end_col = d.range['end'].character,
        severity = sev[d.severity] or vim.diagnostic.severity.ERROR,
        message = d.message .. (d.help and ('\n  help: ' .. d.help) or ''),
        source = 'nixfmt', code = d.code,
      }
      for _, rel in ipairs(d.relatedInformation or {}) do
        -- surface related spans as inline hints
        diags[#diags + 1] = {
          lnum = rel.range.start.line, col = rel.range.start.character,
          end_lnum = rel.range['end'].line, end_col = rel.range['end'].character,
          severity = vim.diagnostic.severity.HINT,
          message = rel.message, source = 'nixfmt',
        }
        item.user_data = { lsp = { relatedInformation = d.relatedInformation } }
      end
      diags[#diags + 1] = item
    elseif ok and d.message then
      diags[#diags + 1] = {
        lnum = 0, col = 0,
        severity = sev[d.severity] or vim.diagnostic.severity.WARN,
        message = d.message, source = 'nixfmt',
      }
    end
  end
  vim.diagnostic.set(ns, buf, diags)
end

vim.api.nvim_create_autocmd({ 'BufReadPost', 'BufWritePost' }, {
  pattern = '*.nix',
  callback = function(a) publish(a.buf) end,
})
```

</details>

```nix
{
  foo = 1;
  bar = {
    baz = 2;
}
```
