### PR TITLE
feat: use `clap` for CLi argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,10 +27,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
 
 [[package]]
 name = "anyhow"
@@ -139,6 +183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -147,8 +192,22 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -156,6 +215,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -382,6 +447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +558,7 @@ dependencies = [
 name = "nixfmt_rs"
 version = "0.2.0"
 dependencies = [
+ "clap",
  "compact_str",
  "criterion",
  "ignore",
@@ -519,6 +591,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -749,6 +827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +877,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 [features]
 default = ["cli"]
 # Library consumers disable default features to skip binary-only deps.
-cli = ["dep:ignore", "dep:mimalloc", "debug-dump"]
+cli = ["dep:clap", "dep:ignore", "dep:mimalloc", "debug-dump"]
 # Enables format_ast/format_ir (Haskell-parity --ast/--ir dumps). No extra deps;
 # split from `cli` so the fuzz crate can exercise the dumpers without pulling
 # in ignore/mimalloc.
@@ -42,6 +42,7 @@ sweep = ["dep:rayon", "dep:walkdir"]
 [dependencies]
 memchr = "2"
 compact_str = "0.9"
+clap = { version = "4", features = ["derive"], optional = true }
 criterion = { version = "0.8", optional = true }
 rayon = { version = "1", optional = true }
 walkdir = { version = "2", optional = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 
 use std::io::{self, Read, Write};
 
+use clap::{CommandFactory, Parser, ValueEnum};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use std::path::Path;
@@ -14,31 +15,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use nixfmt_rs::VERSION;
 
 mod json_diag;
-
-const HELP: &str = "\
-nixfmt-rs [OPTIONS] [FILES or -]
-  Format Nix source code (Rust implementation of nixfmt)
-  Use '-' as a file argument to read from stdin.
-
-Common flags:
-  -w --width=INT        Maximum width in characters [default: 100]
-     --indent=INT       Number of spaces to use for indentation [default: 2]
-  -c --check            Check whether files are formatted without modifying them
-  -m --mergetool        Git mergetool mode: format BASE/LOCAL/REMOTE, run
-                        'git merge-file', format and move result to MERGED
-  -q --quiet            Do not report errors
-  -s --strict           Enable a stricter formatting mode (accepted, currently no-op)
-  -v --verify           Apply sanity checks on the output after formatting
-  -a --ast              Pretty print the internal AST to stderr (debug)
-  -f --filename=ITEM    Filename to display when input is read from stdin
-     --ir               Pretty print the internal IR to stderr (debug)
-     --message-format=FMT
-                        How to render diagnostics: 'human' (default) or 'json'
-                        (one JSON object per line on stderr, LSP Diagnostic shape)
-  -? --help             Display help message
-  -V --version          Print version information
-     --numeric-version  Print just the version number
-";
 
 #[derive(Default)]
 #[allow(clippy::struct_excessive_bools)] // flat CLI flag bag
@@ -59,76 +35,135 @@ struct Opts {
     files: Vec<String>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum MessageFormat {
+    Human,
+    Json,
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "nixfmt-rs",
+    about = env!("CARGO_PKG_DESCRIPTION"),
+    long_about = "Format Nix source code (Rust implementation of nixfmt).\nUse '-' as a file argument to read from stdin.",
+    disable_help_flag = true,
+    disable_version_flag = true,
+    trailing_var_arg = true
+)]
+struct CliArgs {
+    #[arg(
+        short = 'w',
+        long = "width",
+        default_value_t = 100,
+        help = "Maximum width in characters"
+    )]
+    width: usize,
+    #[arg(
+        long = "indent",
+        default_value_t = 2,
+        help = "Number of spaces to use for indentation"
+    )]
+    indent: usize,
+    #[arg(
+        short = 'c',
+        long = "check",
+        help = "Check whether files are formatted without modifying them"
+    )]
+    check: bool,
+    #[arg(short = 'q', long = "quiet", help = "Do not report errors")]
+    quiet: bool,
+    #[arg(
+        short = 's',
+        long = "strict",
+        help = "Enable a stricter formatting mode (accepted, currently no-op)"
+    )]
+    strict: bool,
+    #[arg(
+        short = 'v',
+        long = "verify",
+        help = "Apply sanity checks on the output after formatting"
+    )]
+    verify: bool,
+    #[arg(
+        short = 'a',
+        long = "ast",
+        help = "Pretty print the internal AST to stderr (debug)"
+    )]
+    ast: bool,
+    #[arg(long = "ir", help = "Pretty print the internal IR to stderr (debug)")]
+    ir: bool,
+    #[arg(long = "parse-only", help = "Only parse input and report parse errors")]
+    parse_only: bool,
+    #[arg(
+        short = 'm',
+        long = "mergetool",
+        help = "Git mergetool mode: format BASE/LOCAL/REMOTE, run git merge-file, format and move result to MERGED"
+    )]
+    mergetool: bool,
+    #[arg(
+        long = "message-format",
+        value_enum,
+        default_value = "human",
+        help = "How to render diagnostics: human or json"
+    )]
+    message_format: MessageFormat,
+    #[arg(
+        short = 'f',
+        long = "filename",
+        help = "Filename to display when input is read from stdin"
+    )]
+    filename: Option<String>,
+    #[arg(short = '?', long = "help")]
+    help: bool,
+    #[arg(short = 'V', long = "version")]
+    version: bool,
+    #[arg(long = "numeric-version", help = "Print just the version number")]
+    numeric_version: bool,
+    #[arg(value_name = "FILES or -")]
+    files: Vec<String>,
+}
+
 fn parse_args() -> Result<Opts, String> {
-    let mut o = Opts {
-        width: 100,
-        indent: 2,
-        ..Opts::default()
-    };
-    let mut args = std::env::args().skip(1);
-    while let Some(arg) = args.next() {
-        let (flag, inline) = match arg.split_once('=') {
-            Some((f, v)) => (f.to_string(), Some(v.to_string())),
-            None => (arg.clone(), None),
-        };
-        let mut value = |name: &str| -> Result<String, String> {
-            if let Some(v) = inline.clone() {
-                return Ok(v);
+    let cli = CliArgs::try_parse().map_err(|e| {
+        if matches!(e.kind(), clap::error::ErrorKind::UnknownArgument) {
+            let argv = std::env::args().skip(1);
+            if let Some(flag) = argv.into_iter().find(|a| a.starts_with('-')) {
+                return format!("Unknown flag: {flag}");
             }
-            args.next()
-                .ok_or_else(|| format!("Missing value for flag: {name}"))
-        };
-        let mut int = |name: &str| -> Result<usize, String> {
-            value(name)?
-                .parse()
-                .map_err(|_| format!("Invalid integer for {name}"))
-        };
-        match flag.as_str() {
-            "-?" | "--help" => {
-                print!("{HELP}");
-                exit(0);
-            }
-            "-V" | "--version" => {
-                println!("nixfmt-rs {VERSION}");
-                exit(0);
-            }
-            "--numeric-version" => {
-                println!("{VERSION}");
-                exit(0);
-            }
-            "-w" | "--width" => o.width = int("--width")?,
-            "--indent" => o.indent = int("--indent")?,
-            "-c" | "--check" => o.check = true,
-            "-q" | "--quiet" => o.quiet = true,
-            "-s" | "--strict" => o.strict = true,
-            "-v" | "--verify" => o.verify = true,
-            "-a" | "--ast" => o.ast = true,
-            "--ir" => o.ir = true,
-            "--parse-only" => o.parse_only = true,
-            "-m" | "--mergetool" => o.mergetool = true,
-            "--message-format" => {
-                let v = value("--message-format")?;
-                o.json_diagnostics = match v.as_str() {
-                    "human" => false,
-                    "json" => true,
-                    other => return Err(format!("Unknown --message-format: {other}")),
-                };
-            }
-            "-f" | "--filename" => o.filename = Some(value("--filename")?),
-            "--" => {
-                o.files.extend(args.by_ref());
-            }
-            s if s.starts_with("-w") && !s.starts_with("--") && s.len() > 2 => {
-                o.width = s[2..]
-                    .parse()
-                    .map_err(|_| "Invalid integer for --width".to_string())?;
-            }
-            "-" => o.files.push("-".to_string()),
-            s if s.starts_with('-') => return Err(format!("Unknown flag: {s}")),
-            _ => o.files.push(arg),
         }
+        e.to_string()
+    })?;
+
+    if cli.help {
+        let mut cmd = CliArgs::command();
+        cmd.print_help().map_err(|e| e.to_string())?;
+        println!();
+        exit(0);
     }
-    Ok(o)
+    if cli.version {
+        println!("nixfmt-rs {VERSION}");
+        exit(0);
+    }
+    if cli.numeric_version {
+        println!("{VERSION}");
+        exit(0);
+    }
+
+    Ok(Opts {
+        width: cli.width,
+        indent: cli.indent,
+        check: cli.check,
+        quiet: cli.quiet,
+        strict: cli.strict,
+        verify: cli.verify,
+        ast: cli.ast,
+        ir: cli.ir,
+        parse_only: cli.parse_only,
+        mergetool: cli.mergetool,
+        json_diagnostics: matches!(cli.message_format, MessageFormat::Json),
+        filename: cli.filename,
+        files: cli.files,
+    })
 }
 
 fn render_err(o: &Opts, source: &str, name: &str, e: &nixfmt_rs::ParseError) -> String {


### PR DESCRIPTION
Hello,

Here's the PR implementing `clap`. I still think moving to it has strong long-term benefits despite the compile-time cost. IMO, the main value for me is not just convenience, but reducing maintenance and edge-case risk in the CLI handling.

- More robust argument validation out of the box (quite self-explanitory)
- Better UX and docs for users (auto-generated `--help`, typo suggestions, value hints, standardized look'n'feel)
- Easier evolution of the CLI (quite self-explanitory)
- Lower maintenance burden over time

That said, I agree compile-time impact is a downside, and this is the reason why I pushed this PR so you can make benchmarks and decide. My goal here is mostly maintainability and predictable CLI behavior in the long run, not adding dependency weight for no reason.

```
❯ ./target/debug/nixfmt --help
Format Nix source code (Rust implementation of nixfmt)

Usage: nixfmt-rs [OPTIONS] [FILES or -]...

Arguments:
  [FILES or -]...

Options:
  -w, --width <WIDTH>
          Maximum width in characters [default: 100]
      --indent <INDENT>
          Number of spaces to use for indentation [default: 2]
  -c, --check
          Check whether files are formatted without modifying them
  -q, --quiet
          Do not report errors
  -s, --strict
          Enable a stricter formatting mode (accepted, currently no-op)
  -v, --verify
          Apply sanity checks on the output after formatting
  -a, --ast
          Pretty print the internal AST to stderr (debug)
      --ir
          Pretty print the internal IR to stderr (debug)
      --parse-only
          Only parse input and report parse errors
  -m, --mergetool
          Git mergetool mode: format BASE/LOCAL/REMOTE, run git merge-file, format and move result to MERGED
      --message-format <MESSAGE_FORMAT>
          How to render diagnostics: human or json [default: human] [possible values: human, json]
  -f, --filename <FILENAME>
          Filename to display when input is read from stdin
  -?, --help

  -V, --version

      --numeric-version
          Print just the version number
```

Linked issue: #60 