### PR TITLE
cli: replace hand-rolled arg parser with lexopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexopt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +496,7 @@ dependencies = [
  "compact_str",
  "criterion",
  "ignore",
+ "lexopt",
  "memchr",
  "mimalloc",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ path = "src/lib.rs"
 [features]
 default = ["cli"]
 # Library consumers disable default features to skip binary-only deps.
-cli = ["dep:ignore", "dep:mimalloc", "debug-dump"]
+cli = ["dep:ignore", "dep:mimalloc", "dep:lexopt", "debug-dump"]
 # Enables format_ast/format_ir (Haskell-parity --ast/--ir dumps). No extra deps;
 # split from `cli` so the fuzz crate can exercise the dumpers without pulling
 # in ignore/mimalloc.
@@ -48,6 +48,7 @@ walkdir = { version = "2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ignore = { version = "0.4", optional = true }
+lexopt = { version = "0.3", optional = true }
 mimalloc = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The binary is named `nixfmt` and is flag-compatible with upstream.
 
 ```bash
 # stdin → stdout
-echo '{a=1;}' | nixfmt
+echo '{a=1;}' | nixfmt -
 
 # Format files / directories in place (recurses into *.nix, parallel)
 nixfmt path/to/file.nix path/to/dir
@@ -158,13 +158,13 @@ require("conform").setup({ formatters_by_ft = { nix = { "nixfmt" } } })
 ```toml
 [[language]]
 name = "nix"
-formatter = { command = "nixfmt" }
+formatter = { command = "nixfmt", args = ["-"] }
 ```
 
 **Emacs** ([apheleia](https://github.com/radian-software/apheleia)): `nixfmt`
 is built in; just ensure the binary resolves to this one.
 
-**Anything else**: pipe the buffer through `nixfmt` (reads stdin, writes
+**Anything else**: pipe the buffer through `nixfmt -` (reads stdin, writes
 stdout, exit 1 on parse error).
 
 </details>

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ Common flags:
      --message-format=FMT
                         How to render diagnostics: 'human' (default) or 'json'
                         (one JSON object per line on stderr, LSP Diagnostic shape)
-  -? --help             Display help message
+  -h -? --help          Display help message
   -V --version          Print version information
      --numeric-version  Print just the version number
 ";
@@ -59,73 +59,53 @@ struct Opts {
     files: Vec<String>,
 }
 
-fn parse_args() -> Result<Opts, String> {
+fn parse_args() -> Result<Opts, lexopt::Error> {
+    use lexopt::prelude::*;
     let mut o = Opts {
         width: 100,
         indent: 2,
         ..Opts::default()
     };
-    let mut args = std::env::args().skip(1);
-    while let Some(arg) = args.next() {
-        let (flag, inline) = match arg.split_once('=') {
-            Some((f, v)) => (f.to_string(), Some(v.to_string())),
-            None => (arg.clone(), None),
-        };
-        let mut value = |name: &str| -> Result<String, String> {
-            if let Some(v) = inline.clone() {
-                return Ok(v);
-            }
-            args.next()
-                .ok_or_else(|| format!("Missing value for flag: {name}"))
-        };
-        let mut int = |name: &str| -> Result<usize, String> {
-            value(name)?
-                .parse()
-                .map_err(|_| format!("Invalid integer for {name}"))
-        };
-        match flag.as_str() {
-            "-?" | "--help" => {
+    let mut p = lexopt::Parser::from_env();
+    while let Some(arg) = p.next()? {
+        match arg {
+            Short('h' | '?') | Long("help") => {
                 print!("{HELP}");
                 exit(0);
             }
-            "-V" | "--version" => {
+            Short('V') | Long("version") => {
                 println!("nixfmt-rs {VERSION}");
                 exit(0);
             }
-            "--numeric-version" => {
+            Long("numeric-version") => {
                 println!("{VERSION}");
                 exit(0);
             }
-            "-w" | "--width" => o.width = int("--width")?,
-            "--indent" => o.indent = int("--indent")?,
-            "-c" | "--check" => o.check = true,
-            "-q" | "--quiet" => o.quiet = true,
-            "-s" | "--strict" => o.strict = true,
-            "-v" | "--verify" => o.verify = true,
-            "-a" | "--ast" => o.ast = true,
-            "--ir" => o.ir = true,
-            "--parse-only" => o.parse_only = true,
-            "-m" | "--mergetool" => o.mergetool = true,
-            "--message-format" => {
-                let v = value("--message-format")?;
+            Short('w') | Long("width") => o.width = p.value()?.parse()?,
+            Long("indent") => o.indent = p.value()?.parse()?,
+            Short('c') | Long("check") => o.check = true,
+            Short('q') | Long("quiet") => o.quiet = true,
+            Short('s') | Long("strict") => o.strict = true,
+            Short('v') | Long("verify") => o.verify = true,
+            Short('a') | Long("ast") => o.ast = true,
+            Long("ir") => o.ir = true,
+            Long("parse-only") => o.parse_only = true,
+            Short('m') | Long("mergetool") => o.mergetool = true,
+            Long("message-format") => {
+                let v = p.value()?.string()?;
                 o.json_diagnostics = match v.as_str() {
                     "human" => false,
                     "json" => true,
-                    other => return Err(format!("Unknown --message-format: {other}")),
+                    other => {
+                        return Err(lexopt::Error::Custom(
+                            format!("Unknown --message-format: {other}").into(),
+                        ));
+                    }
                 };
             }
-            "-f" | "--filename" => o.filename = Some(value("--filename")?),
-            "--" => {
-                o.files.extend(args.by_ref());
-            }
-            s if s.starts_with("-w") && !s.starts_with("--") && s.len() > 2 => {
-                o.width = s[2..]
-                    .parse()
-                    .map_err(|_| "Invalid integer for --width".to_string())?;
-            }
-            "-" => o.files.push("-".to_string()),
-            s if s.starts_with('-') => return Err(format!("Unknown flag: {s}")),
-            _ => o.files.push(arg),
+            Short('f') | Long("filename") => o.filename = Some(p.value()?.string()?),
+            Value(path) => o.files.push(path.string()?),
+            _ => return Err(arg.unexpected()),
         }
     }
     Ok(o)

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -282,10 +282,7 @@ fn quiet_suppresses_errors_but_keeps_exit_code() {
     let ref_out = nixfmt(&["-q"], Some(INVALID));
     assert_eq!(ref_out.status.code(), Some(1));
     assert!(ref_out.stderr.is_empty());
-}
 
-#[test]
-fn quiet_suppresses_check_message() {
     let out = ours(&["-c", "-q"], Some(UNFORMATTED));
     assert_eq!(out.status.code(), Some(1));
     assert!(out.stderr.is_empty());
@@ -301,11 +298,6 @@ fn width_flag_forces_multiline() {
         narrow_s.lines().count() > 1,
         "expected multi-line at width 10, got {narrow_s:?}"
     );
-
-    let alt = ours(&["-w", "10"], Some(src));
-    assert_eq!(alt.stdout, narrow.stdout);
-    let alt2 = ours(&["-w10"], Some(src));
-    assert_eq!(alt2.stdout, narrow.stdout);
 
     let ref_out = nixfmt(&["--width=10"], Some(src));
     assert_eq!(narrow.stdout, ref_out.stdout);
@@ -349,13 +341,6 @@ fn ast_on_file_does_not_modify() {
 }
 
 #[test]
-fn strict_flag_is_accepted() {
-    let out = ours(&["--strict"], Some(FORMATTED));
-    assert!(out.status.success());
-    assert_eq!(String::from_utf8_lossy(&out.stdout), FORMATTED);
-}
-
-#[test]
 fn verify_flag_is_accepted() {
     let out = ours(&["--verify"], Some(UNFORMATTED));
     assert!(out.status.success());
@@ -375,10 +360,7 @@ fn filename_flag_used_in_errors() {
     let ref_out = nixfmt(&["--filename=custom.nix"], Some(INVALID));
     let ref_err = String::from_utf8_lossy(&ref_out.stderr);
     assert!(ref_err.contains("custom.nix"));
-}
 
-#[test]
-fn filename_flag_used_in_check_message() {
     let out = ours(&["-c", "--filename", "foo.nix"], Some(UNFORMATTED));
     assert_eq!(out.status.code(), Some(1));
     let stderr = String::from_utf8_lossy(&out.stderr);
@@ -386,16 +368,6 @@ fn filename_flag_used_in_check_message() {
         stderr.contains("foo.nix: not formatted"),
         "stderr={stderr:?}"
     );
-}
-
-#[test]
-fn help_exits_0() {
-    let out = ours(&["--help"], None);
-    assert_eq!(out.status.code(), Some(0));
-    assert!(String::from_utf8_lossy(&out.stdout).contains("--check"));
-
-    let ref_out = nixfmt(&["--help"], None);
-    assert_eq!(ref_out.status.code(), Some(0));
 }
 
 #[test]
@@ -410,15 +382,6 @@ fn version_flags() {
         String::from_utf8_lossy(&out.stdout).trim(),
         env!("CARGO_PKG_VERSION")
     );
-}
-
-#[test]
-fn unknown_long_flag_starting_with_w() {
-    // Regression: `-wNN` shorthand must not swallow unrelated `--w*` flags.
-    let out = ours(&["--wrong"], None);
-    assert_eq!(out.status.code(), Some(1));
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("Unknown flag"), "stderr={stderr:?}");
 }
 
 #[test]
@@ -481,7 +444,10 @@ fn unknown_flag_exits_1() {
     let out = ours(&["--bogus"], None);
     assert_eq!(out.status.code(), Some(1));
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("Unknown flag"), "stderr={stderr:?}");
+    assert!(
+        stderr.contains("invalid option '--bogus'"),
+        "stderr={stderr:?}"
+    );
 
     let ref_out = nixfmt(&["--bogus"], None);
     assert_eq!(ref_out.status.code(), Some(1));


### PR DESCRIPTION
The bespoke parser had ad-hoc hacks (-wN, manual --key=value) yet still lacked combined short flags. lexopt is a single zero-dep file that handles all of it correctly, trimming ~20 lines. Also accept -h for help alongside -?. Gated behind the cli feature so library/wasm builds are unaffected.