### PR TITLE
doc/fixup: thread leading Hardspace as a flag, not insert(0, ..)

### DIFF
--- a/src/doc/render/fixup.rs
+++ b/src/doc/render/fixup.rs
@@ -90,7 +90,22 @@ fn split_liftable(ann: GroupKind, mut body: Doc) -> GroupFixup {
 /// (`write_idx <= read_idx`), recursing into group bodies via `&mut` so the
 /// existing `Vec` allocations are reused. Mirrors Haskell `fixup`
 /// clause-by-clause; see the per-arm comments for the corresponding rule.
-pub(super) fn fixup_mut(doc: &mut Vec<Elem>, mut nest_acc: isize, mut offset_acc: isize) {
+///
+/// `pull_hardspace` means "a `Hardspace` immediately precedes `doc` in the
+/// parent and should merge with `doc`'s leading content". This implements the
+/// `Spacing Hardspace : Group ann xs` rule without an O(n) `insert(0, ..)`.
+/// Returns whether that virtual `Hardspace` was absorbed into `doc`'s output;
+/// if not, the caller keeps it in place.
+#[allow(clippy::too_many_lines)]
+pub(super) fn fixup_mut(
+    doc: &mut Vec<Elem>,
+    mut nest_acc: isize,
+    mut offset_acc: isize,
+    pull_hardspace: bool,
+) -> bool {
+    // Only meaningful while `write_idx == 0`; once anything is written the
+    // virtual Hardspace is positionally before it and can no longer merge.
+    let mut virtual_hs = pull_hardspace;
     let mut read_idx = 0usize;
     let mut write_idx = 0usize;
     while read_idx < doc.len() {
@@ -104,7 +119,11 @@ pub(super) fn fixup_mut(doc: &mut Vec<Elem>, mut nest_acc: isize, mut offset_acc
 
             // `Spacing a : Spacing b : ys` — fold into the next slot, or into
             // the previous written slot when a `Nest` marker sat in between.
-            Elem::Spacing(a) => {
+            Elem::Spacing(mut a) => {
+                if write_idx == 0 && virtual_hs {
+                    a = Spacing::Hardspace.merge(a);
+                    virtual_hs = false;
+                }
                 if let Some(Elem::Spacing(b)) = doc.get(read_idx) {
                     doc[read_idx] = Elem::Spacing(a.merge(*b));
                 } else if matches!(
@@ -139,15 +158,21 @@ pub(super) fn fixup_mut(doc: &mut Vec<Elem>, mut nest_acc: isize, mut offset_acc
 
             Elem::Group(ann, mut body) => {
                 // `Spacing Hardspace : Group ann xs : ys` — pull a just-written
-                // hardspace into the group so it can merge with a leading soft
-                // spacing during the recursive fixup.
-                if write_idx > 0 && matches!(doc[write_idx - 1], Elem::Spacing(Spacing::Hardspace))
-                {
-                    write_idx -= 1;
-                    doc[write_idx] = HOLE;
-                    body.0.insert(0, Elem::Spacing(Spacing::Hardspace));
+                // (or virtual) hardspace into the group so it can merge with a
+                // leading soft spacing during the recursive fixup.
+                let pull = if write_idx > 0 {
+                    matches!(doc[write_idx - 1], Elem::Spacing(Spacing::Hardspace))
+                } else {
+                    virtual_hs
+                };
+                if fixup_mut(&mut body.0, nest_acc, offset_acc, pull) {
+                    if write_idx > 0 {
+                        write_idx -= 1;
+                        doc[write_idx] = HOLE;
+                    } else {
+                        virtual_hs = false;
+                    }
                 }
-                fixup_mut(&mut body.0, nest_acc, offset_acc);
 
                 match split_liftable(ann, body) {
                     GroupFixup::Keep(body) => {
@@ -202,4 +227,5 @@ pub(super) fn fixup_mut(doc: &mut Vec<Elem>, mut nest_acc: isize, mut offset_acc
         }
     }
     doc.truncate(write_idx);
+    pull_hardspace && !virtual_hs
 }

--- a/src/doc/render/mod.rs
+++ b/src/doc/render/mod.rs
@@ -71,7 +71,7 @@ impl Doc {
     /// Normalise a freshly built document for rendering: lift hard spacings
     /// and comments out of groups, merge adjacent spacings, drop empty groups.
     pub fn fixup(mut self) -> Self {
-        fixup::fixup_mut(&mut self.0, 0, 0);
+        fixup::fixup_mut(&mut self.0, 0, 0, false);
         self
     }
 }

--- a/src/format/term.rs
+++ b/src/format/term.rs
@@ -258,11 +258,10 @@ impl<T: Emit> Items<T> {
                     if i + 1 < items.len()
                         && let Item::Comments(trivia) = &items[i]
                         && trivia.len() == 1
-                        && let TriviaPiece::LanguageAnnotation(lang) = &trivia[0]
+                        && let ann @ TriviaPiece::LanguageAnnotation(_) = &trivia[0]
                         && let Item::Item(string_item) = &items[i + 1]
                     {
-                        TriviaPiece::LanguageAnnotation(lang.clone()).emit(doc);
-                        doc.hardspace();
+                        ann.emit(doc);
                         doc.group(|d| string_item.emit(d));
                         i += 2;
                         continue;


### PR DESCRIPTION

Vec::insert(0, ..) shifted ~1.3M Elems on hackage-packages.nix and in
most cases the Hardspace was lifted straight back out. Pass it as a
flag to the recursive call instead. ~8-12% less CPU on nixpkgs, output
byte-identical.
