### PR TITLE
ast: rename Application/Abstraction to Apply/Lambda

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -216,13 +216,13 @@ pub enum Expression {
         else_branch: Box<Self>,
     },
     /// `param : body`
-    Abstraction {
+    Lambda {
         param: Parameter,
         colon: Leaf,
         body: Box<Self>,
     },
     /// function application
-    Application {
+    Apply {
         func: Box<Self>,
         arg: Box<Self>,
     },
@@ -255,15 +255,15 @@ impl Expression {
     pub fn is_simple(&self) -> bool {
         match self {
             Self::Term(term) => term.is_simple(),
-            Self::Application { func: f, arg: a } => Self::app_is_simple(f, a),
+            Self::Apply { func: f, arg: a } => Self::app_is_simple(f, a),
             _ => false,
         }
     }
 
     pub fn app_is_simple(f: &Self, a: &Self) -> bool {
         // No more than two arguments.
-        if let Self::Application { func: f2, .. } = f
-            && matches!(**f2, Self::Application { .. })
+        if let Self::Apply { func: f2, .. } = f
+            && matches!(**f2, Self::Apply { .. })
         {
             return false;
         }
@@ -299,8 +299,8 @@ first_token_impl! { Expression;
     | Self::If { kw_if: kw, .. }
     | Self::Negation { minus: kw, .. }
     | Self::Inversion { bang: kw, .. } => leaf kw,
-    Self::Abstraction { param, .. } => recurse param,
-    Self::Application { func: g, .. }
+    Self::Lambda { param, .. } => recurse param,
+    Self::Apply { func: g, .. }
     | Self::Operation { lhs: g, .. }
     | Self::MemberCheck { lhs: g, .. } => recurse g,
 }

--- a/src/ast_format_tests.rs
+++ b/src/ast_format_tests.rs
@@ -57,7 +57,7 @@ oracle_tests! {
 
     test_if_then_else => ["if true then 1 else 2"],
 
-    // Expression::Abstraction / Parameter::ID
+    // Expression::Lambda / Parameter::ID
     test_simple_lambda => ["x: x"],
 
     // Parameter::Set

--- a/src/dump/ast.rs
+++ b/src/dump/ast.rs
@@ -107,10 +107,11 @@ impl Dump for Expression {
                     ]
                 );
             }
-            Self::Abstraction { param, colon, body } => {
+            Self::Lambda { param, colon, body } => {
+                // Haskell `nixfmt --ast` constructor name; keep for byte-compat.
                 format_constructor!(w, "Abstraction", [param, colon, &**body]);
             }
-            Self::Application { func, arg } => {
+            Self::Apply { func, arg } => {
                 format_constructor!(w, "Application", [&**func, &**arg]);
             }
             Self::Operation { lhs, op, rhs } => {

--- a/src/format/absorb.rs
+++ b/src/format/absorb.rs
@@ -45,13 +45,13 @@ impl Expression {
                 matches!(&**body, Self::Term(t) if t.is_absorbable())
             }
             // Absorb function declarations but only those with simple parameter(s)
-            Self::Abstraction {
+            Self::Lambda {
                 param: Parameter::Id(_),
                 body,
                 ..
             } => match &**body {
                 Self::Term(t) => t.is_absorbable(),
-                Self::Abstraction { .. } => body.is_absorbable(),
+                Self::Lambda { .. } => body.is_absorbable(),
                 _ => false,
             },
             _ => false,
@@ -156,7 +156,7 @@ impl Expression {
 
             // Function call: absorb if all arguments except the last fit on the line,
             // start on a new line otherwise.
-            Self::Application { .. } => {
+            Self::Apply { .. } => {
                 doc.nested(|d| emit_app(d, false, &[line()], false, self));
             }
 

--- a/src/format/app.rs
+++ b/src/format/app.rs
@@ -87,7 +87,7 @@ fn absorb_app(
         });
     };
 
-    let Expression::Application { func: f, arg: a } = expr else {
+    let Expression::Apply { func: f, arg: a } = expr else {
         match head {
             None => absorb_head(doc, expr, indent_function, comment),
             Some(h) => {
@@ -100,7 +100,7 @@ fn absorb_app(
     };
 
     // Two consecutive list arguments stay together: if one wraps, both wrap.
-    let pair_head = if let Expression::Application { func: f2, arg: l1 } = &**f
+    let pair_head = if let Expression::Apply { func: f2, arg: l1 } = &**f
         && matches!(**l1, Expression::Term(Term::List { .. }))
     {
         Some((&**f2, &**l1, head))
@@ -154,7 +154,7 @@ fn absorb_last(doc: &mut Doc, arg: &Expression) {
     }) = arg
     {
         // Parenthesised single-ID-parameter abstraction with absorbable body.
-        if let Expression::Abstraction {
+        if let Expression::Lambda {
             param: Parameter::Id(name),
             colon,
             body,
@@ -175,7 +175,7 @@ fn absorb_last(doc: &mut Doc, arg: &Expression) {
             });
         }
         // Parenthesised `ident { ... }` application with absorbable body.
-        if let Expression::Application { func: f, arg: a } = &**inner
+        if let Expression::Apply { func: f, arg: a } = &**inner
             && let Expression::Term(Term::Token(ident)) = &**f
             && matches!(ident.value, Token::Identifier(_))
             && let Expression::Term(body_term) = &**a
@@ -208,8 +208,8 @@ pub(super) fn emit_app(
     has_post: bool,
     expr: &Expression,
 ) {
-    let Expression::Application { func: f, arg: a } = expr else {
-        unreachable!("emit_app requires an Application");
+    let Expression::Apply { func: f, arg: a } = expr else {
+        unreachable!("emit_app requires an Apply");
     };
     emit_app_parts(doc, indent_function, pre, has_post, f, a, None);
 }
@@ -217,7 +217,7 @@ pub(super) fn emit_app(
 /// As [`emit_app`], but with `func`/`arg` destructured and an optional `head`
 /// virtually prepended at the leftmost position of the chain. Lets `assert`
 /// render `assert cond` as an application without cloning `cond` into a
-/// synthetic `Application` node (the Haskell `insertIntoApp` approach).
+/// synthetic `Apply` node (the Haskell `insertIntoApp` approach).
 pub(super) fn emit_app_parts(
     doc: &mut Doc,
     indent_function: bool,
@@ -239,7 +239,7 @@ pub(super) fn emit_app_parts(
 
     // Two trailing list arguments are rendered as a pair of regular groups so
     // they wrap together; lists are never "simple", so renderSimple cannot apply.
-    let pair_head = if let Expression::Application { func: f2, arg: l1 } = f
+    let pair_head = if let Expression::Apply { func: f2, arg: l1 } = f
         && matches!(**l1, Expression::Term(Term::List { .. }))
     {
         Some((&**f2, &**l1, head))

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -113,7 +113,7 @@ impl Emit for Expression {
     fn emit(&self, doc: &mut Doc) {
         match self {
             Self::Term(t) => t.emit(doc),
-            Self::Application { .. } => {
+            Self::Apply { .. } => {
                 emit_app(doc, false, &[], false, self);
             }
             Self::Operation {
@@ -186,7 +186,7 @@ impl Emit for Expression {
                 doc.group(|g| {
                     let assert_term = Self::Term(Term::Token(assert_kw.clone()));
                     match &**cond {
-                        Self::Application { func, arg } => {
+                        Self::Apply { func, arg } => {
                             emit_app_parts(g, false, &[], false, func, arg, Some(&assert_term));
                         }
                         a => emit_app_parts(g, false, &[], false, &assert_term, a, None),
@@ -204,7 +204,7 @@ impl Emit for Expression {
             } => {
                 emit_with(doc, with_kw, env, semicolon, expr);
             }
-            Self::Abstraction {
+            Self::Lambda {
                 param: Parameter::Id(param),
                 colon,
                 body,
@@ -213,10 +213,10 @@ impl Emit for Expression {
                     group_doc.linebreak();
                     param.emit(group_doc);
                     colon.emit(group_doc);
-                    body.absorb_abs(group_doc, 1);
+                    body.absorb_lambda(group_doc, 1);
                 });
             }
-            Self::Abstraction { param, colon, body } => {
+            Self::Lambda { param, colon, body } => {
                 param.emit(doc);
                 colon.emit(doc);
                 doc.line();

--- a/src/format/op.rs
+++ b/src/format/op.rs
@@ -34,7 +34,7 @@ fn absorb_operation(doc: &mut Doc, expr: &Expression) {
                 expr.emit(group_doc);
             });
         }
-        Expression::Application { .. } => {
+        Expression::Apply { .. } => {
             doc.group(|g| emit_app(g, false, &[line()], false, expr));
         }
         _ => {

--- a/src/format/params.rs
+++ b/src/format/params.rs
@@ -77,8 +77,8 @@ fn take_last_trail_comment_expr(expr: &mut Expression) -> Option<TrailingComment
         | Expression::If {
             else_branch: body, ..
         }
-        | Expression::Abstraction { body, .. }
-        | Expression::Application { arg: body, .. }
+        | Expression::Lambda { body, .. }
+        | Expression::Apply { arg: body, .. }
         | Expression::Operation { rhs: body, .. }
         | Expression::Negation { expr: body, .. }
         | Expression::Inversion { expr: body, .. } => take_last_trail_comment_expr(body),

--- a/src/format/stmt.rs
+++ b/src/format/stmt.rs
@@ -4,9 +4,9 @@ use crate::doc::{Doc, Elem, Emit, hardline, line};
 use super::Width;
 
 impl Expression {
-    pub(in crate::format) fn absorb_abs(&self, doc: &mut Doc, depth: usize) {
+    pub(in crate::format) fn absorb_lambda(&self, doc: &mut Doc, depth: usize) {
         match self {
-            Self::Abstraction {
+            Self::Lambda {
                 param: Parameter::Id(param),
                 colon,
                 body,
@@ -14,7 +14,7 @@ impl Expression {
                 doc.hardspace();
                 param.emit(doc);
                 colon.emit(doc);
-                body.absorb_abs(doc, depth + 1);
+                body.absorb_lambda(doc, depth + 1);
             }
             _ if self.is_absorbable() => {
                 doc.hardspace();

--- a/src/format/term.rs
+++ b/src/format/term.rs
@@ -282,7 +282,7 @@ impl Expression {
             _ if self.is_absorbable() => {
                 doc.group(|inner| self.absorb(inner, Width::Regular));
             }
-            Self::Application { .. } => {
+            Self::Apply { .. } => {
                 emit_app(doc, true, &[], true, self);
             }
             Self::Term(Term::Selection { base: term, .. }) if term.is_absorbable() => {

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -243,12 +243,12 @@ fn normalize_expr(e: &mut Expression) {
             normalize_leaf(kw_else);
             normalize_expr(else_branch);
         }
-        Expression::Abstraction { param, colon, body } => {
+        Expression::Lambda { param, colon, body } => {
             normalize_parameter(param);
             normalize_leaf(colon);
             normalize_expr(body);
         }
-        Expression::Application { func, arg } => {
+        Expression::Apply { func, arg } => {
             normalize_expr(func);
             normalize_expr(arg);
         }

--- a/src/parser/binders.rs
+++ b/src/parser/binders.rs
@@ -97,11 +97,11 @@ impl Parser {
         let eq = self.expect_token(Token::TAssign, "'='")?;
         let expr = self.parse_expression()?;
 
-        // Special case: if the expression is an Application, the user likely forgot
+        // Special case: if the expression is an Apply, the user likely forgot
         // a semicolon and the parser treated the next line as a function argument.
         // Point to the end of the LEFT side (the function) instead of the RIGHT side.
         let expr_end_span = match &expr {
-            Expression::Application { func, .. } => func.end_span(),
+            Expression::Apply { func, .. } => func.end_span(),
             _ => expr.end_span(),
         };
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -210,7 +210,7 @@ impl Parser {
 
     /// After a candidate lambda parameter `first` has been parsed, try to
     /// consume the optional `@ second` part and the mandatory `: body` and
-    /// build an `Expression::Abstraction`.
+    /// build an `Expression::Lambda`.
     ///
     /// * `Lambda(expr)` – a full abstraction was parsed.
     /// * `Set(first)` – neither `:` nor `@` follows; `first` is handed
@@ -221,7 +221,7 @@ impl Parser {
             Token::TColon => {
                 let colon = self.take_and_advance()?;
                 let body = self.parse_expression()?;
-                Ok(SetOrLambda::Lambda(Expression::Abstraction {
+                Ok(SetOrLambda::Lambda(Expression::Lambda {
                     param: first,
                     colon,
                     body: Box::new(body),
@@ -246,7 +246,7 @@ impl Parser {
                 }
                 let colon = self.expect_token(Token::TColon, "':'")?;
                 let body = self.parse_expression()?;
-                Ok(SetOrLambda::Lambda(Expression::Abstraction {
+                Ok(SetOrLambda::Lambda(Expression::Lambda {
                     param: Parameter::Context {
                         lhs: Box::new(first),
                         at: at_tok,

--- a/src/parser/operators.rs
+++ b/src/parser/operators.rs
@@ -67,7 +67,7 @@ impl Parser {
             let mut app_expr = expr;
             while self.is_term_start() && !self.is_expression_end() {
                 let arg = Expression::Term(self.parse_term()?);
-                app_expr = Expression::Application {
+                app_expr = Expression::Apply {
                     func: Box::new(app_expr),
                     arg: Box::new(arg),
                 };

--- a/src/parser/spans.rs
+++ b/src/parser/spans.rs
@@ -16,8 +16,8 @@ impl Expression {
             | Self::If {
                 else_branch: expr, ..
             }
-            | Self::Abstraction { body: expr, .. }
-            | Self::Application { arg: expr, .. }
+            | Self::Lambda { body: expr, .. }
+            | Self::Apply { arg: expr, .. }
             | Self::Operation { rhs: expr, .. }
             | Self::Negation { expr, .. }
             | Self::Inversion { expr, .. } => expr.end_span(),

--- a/src/parser/term.rs
+++ b/src/parser/term.rs
@@ -6,7 +6,7 @@ use crate::error::{ParseError, Result};
 
 impl Parser {
     /// Parse function application (left-associative)
-    /// Application only consumes TERMS, not unary expressions
+    /// Apply only consumes TERMS, not unary expressions
     pub(super) fn parse_application(&mut self) -> Result<Expression> {
         // Prefix unary operators recurse so that postfix `?` (handled below) binds tighter.
         match &self.current.value {
@@ -35,7 +35,7 @@ impl Parser {
         // IMPORTANT: Don't treat binary operators as term starts even if they could start paths
         while self.is_term_start() && !self.is_binary_op() && !self.is_expression_end() {
             let arg = Expression::Term(self.parse_term()?);
-            expr = Expression::Application {
+            expr = Expression::Apply {
                 func: Box::new(expr),
                 arg: Box::new(arg),
             };

--- a/src/regression_tests/parser.rs
+++ b/src/regression_tests/parser.rs
@@ -182,7 +182,7 @@ oracle_tests! {
         "\"\u{00AD}~~~\"",
     ],
 
-    // Application(mkDefault, /tmp), not Path("mkDefault/tmp").
+    // Apply(mkDefault, /tmp), not Path("mkDefault/tmp").
     // From nixpkgs/nixos/modules/services/monitoring/prometheus/exporters.nix line 353
     regression_identifier_slash_path => ["mkDefault /tmp"],
 


### PR DESCRIPTION

Match rnix-parser and common Rust naming instead of the lambda-calculus
terms inherited from the Haskell AST.


