### PR TITLE
readme: advertise idempotency and fuzzing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ A drop-in replacement for [nixfmt]: same binary name, same flags, **byte-identic
   [WebAssembly build](https://mic92.github.io/nixfmt-rs/).
 - **Helpful errors.** rustc-style diagnostics with source snippets and
   fix-it hints ([examples](#error-messages)).
+- **Correct.** Idempotent and AST-preserving by construction; both
+  invariants are [continuously fuzzed](fuzz) and have surfaced bugs
+  in upstream nixfmt as well as our own.
 
 [nixfmt]: https://github.com/NixOS/nixfmt
 


### PR DESCRIPTION

The fuzz harness and the property suite have been catching real bugs
(including upstream ones now carried in nix/patches/), but the README
gave no hint that these guarantees exist or are enforced. Surface them
as a top-level "Correct" bullet and a short Fuzzing section so users
evaluating the project see idempotency and AST preservation are checked
invariants, not aspirations.
