### PR TITLE
Add /*nixfmt:disable*/ and /*nixfmt:enable*/ comment directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,30 @@ echo '{a=1;}' | nixfmt --ast
 echo '{a=1;}' | nixfmt --ir
 ```
 
+### Disabling formatting for a region
+
+Wrap a region in `/*nixfmt:disable*/` and `/*nixfmt:enable*/` to keep it
+verbatim, e.g. for hand-aligned tables:
+
+```nix
+{
+  formatted = 1;
+
+  /*nixfmt:disable*/
+  aligned    =    1;
+  table      =    2;
+  here       =    3;
+  /*nixfmt:enable*/
+
+  alsoFormatted = 2;
+}
+```
+
+Each directive must be on its own line (only whitespace around it). An
+unclosed `/*nixfmt:disable*/` extends to the end of the file. Directives
+inside string literals are ignored; directives inside `${}` interpolations
+are honored, since interpolations contain real Nix code.
+
 ## treefmt
 
 The binary is a drop-in for `nixfmt`, so with [treefmt-nix] just override the

--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Run a cargo-fuzz target inside the nix fuzz shell.
+# Usage: ./fuzz/fuzz.sh <target> [seconds] [extra-libfuzzer-args...]
+# Example: ./fuzz/fuzz.sh fuzz_idempotent 120
+set -euo pipefail
+
+target="${1:?usage: fuzz.sh <target> [seconds] [extra-args...]}"
+seconds="${2:-0}"
+shift 2 2>/dev/null || shift $# 2>/dev/null
+
+time_flag=()
+if [ "$seconds" -gt 0 ] 2>/dev/null; then
+  time_flag=(-max_total_time="$seconds")
+fi
+
+exec nix develop .#fuzz -c \
+  cargo fuzz run "$target" -s none -- "${time_flag[@]}" "$@"

--- a/fuzz/seeds/directive-basic.nix
+++ b/fuzz/seeds/directive-basic.nix
@@ -1,0 +1,7 @@
+{
+  x = 1;
+/*nixfmt:disable*/
+  y    =    2;
+/*nixfmt:enable*/
+  z = 3;
+}

--- a/fuzz/seeds/directive-edge.nix
+++ b/fuzz/seeds/directive-edge.nix
@@ -1,0 +1,2 @@
+/*nixfmt:disable*/
+1

--- a/fuzz/seeds/directive-multi.nix
+++ b/fuzz/seeds/directive-multi.nix
@@ -1,0 +1,9 @@
+{
+/*nixfmt:disable*/
+  a    =    1;
+/*nixfmt:enable*/
+  b = 2;
+/*nixfmt:disable*/
+  c    =    3;
+/*nixfmt:enable*/
+}

--- a/fuzz/seeds/directive-nested.nix
+++ b/fuzz/seeds/directive-nested.nix
@@ -1,0 +1,17 @@
+{
+  a = {
+    /*nixfmt:disable*/
+    b    =    1;
+    /*nixfmt:enable*/
+  };
+  c = [
+    /*nixfmt:disable*/
+    "x"    "y"    "z"
+    /*nixfmt:enable*/
+  ];
+  d = let
+    /*nixfmt:disable*/
+    e    =    1;
+    /*nixfmt:enable*/
+  in e;
+}

--- a/fuzz/seeds/directive-string.nix
+++ b/fuzz/seeds/directive-string.nix
@@ -1,0 +1,13 @@
+{
+  x = ''
+    /*nixfmt:disable*/
+    not a directive
+  '';
+  y   =   1;
+  z = "${
+/*nixfmt:disable*/
+    1    +    2
+/*nixfmt:enable*/
+  }";
+  w   =   3;
+}

--- a/fuzz/seeds/directive-trailing.nix
+++ b/fuzz/seeds/directive-trailing.nix
@@ -1,0 +1,10 @@
+{
+  a = 1; /*nixfmt:disable*/
+  b   =   2;
+  c = [ /*nixfmt:disable*/
+    "x"   "y"
+  ];
+  d = { /*nixfmt:disable*/
+    e   =   1;
+  };
+}

--- a/fuzz/seeds/directive-unclosed.nix
+++ b/fuzz/seeds/directive-unclosed.nix
@@ -1,0 +1,5 @@
+{
+  x = 1;
+/*nixfmt:disable*/
+  y    =    2;
+}

--- a/src/ast/trivia.rs
+++ b/src/ast/trivia.rs
@@ -9,6 +9,10 @@ pub enum TriviaPiece {
     /// `is_doc` = true for /** */ comments
     BlockComment(bool, Box<[Box<str>]>),
     LanguageAnnotation(Box<str>),
+    /// Format directive: `/*nixfmt:disable*/` (true) or `/*nixfmt:enable*/` (false).
+    /// Recognized as a distinct variant so they are never lifted or converted
+    /// to trailing comments.
+    FormatDirective(bool),
 }
 
 /// Wrapper around a list of trivia items (comments/whitespace).

--- a/src/dump/ast.rs
+++ b/src/dump/ast.rs
@@ -274,25 +274,26 @@ impl Dump for TriviaPiece {
             LineComment(text) => [text],
             BlockComment(is_doc, lines) => [is_doc, lines],
             LanguageAnnotation(text) => [text],
+            FormatDirective(is_disable) => [is_disable],
         });
     }
 
     fn is_simple(&self) -> bool {
-        // In Haskell: constructor applications with simple args can be simple
-        // BlockComment True ["doc"] → all arguments simple → renders inline
-        // BlockComment True ["a","b","c"] → Vec with 3 elements NOT simple → renders multiline
         match self {
-            // Nullary constructor / single string arg are simple.
-            Self::EmptyLine | Self::LineComment(_) | Self::LanguageAnnotation(_) => true,
+            Self::EmptyLine
+            | Self::LineComment(_)
+            | Self::LanguageAnnotation(_)
+            | Self::FormatDirective(_) => true,
             Self::BlockComment(_is_doc, lines) => lines.is_simple(),
         }
     }
 
     fn is_atomic(&self) -> bool {
-        // Only nullary constructors are atomic (single element in parsed form)
-        // EmptyLine → Other "EmptyLine" → atomic
-        // LineComment "x" → Other "LineComment " + StringLit → not atomic
-        matches!(self, Self::EmptyLine)
+        // Atomic = parses to a single token in pretty-simple's grammar.
+        // EmptyLine          → Other "EmptyLine"           → 1 atom
+        // FormatDirective b  → Other "FormatDirective True" → 1 atom (Bool is not a quoted/numeric atom)
+        // LineComment "x"    → Other + StringLit            → 2 atoms
+        matches!(self, Self::EmptyLine | Self::FormatDirective(_))
     }
 }
 

--- a/src/format/base.rs
+++ b/src/format/base.rs
@@ -38,6 +38,12 @@ impl Emit for TriviaPiece {
             Self::LanguageAnnotation(lang) => {
                 doc.comment(format!("/* {lang} */")).hardspace();
             }
+            Self::FormatDirective(true) => {
+                doc.comment("/*nixfmt:disable*/").hardline();
+            }
+            Self::FormatDirective(false) => {
+                doc.comment("/*nixfmt:enable*/").hardline();
+            }
         }
     }
 }

--- a/src/lexer/comments.rs
+++ b/src/lexer/comments.rs
@@ -12,6 +12,31 @@
 use super::{Lexer, RawTrivia};
 
 impl Lexer {
+    /// Try to parse `/*nixfmt:disable*/` or `/*nixfmt:enable*/`.
+    /// Fails (without consuming) unless the rest of the line is whitespace,
+    /// since directives must appear on their own line. Haskell `formatDirective`.
+    pub(super) fn try_parse_format_directive(&mut self) -> Option<RawTrivia> {
+        self.try_with_cursor(|this| {
+            if !this.eat_str("/*nixfmt:") {
+                return None;
+            }
+            let is_disable = if this.eat_str("disable") {
+                true
+            } else if this.eat_str("enable") {
+                false
+            } else {
+                return None;
+            };
+            if !this.eat_str("*/") {
+                return None;
+            }
+            this.peek_to_eol()
+                .bytes()
+                .all(|b| matches!(b, b' ' | b'\t'))
+                .then_some(RawTrivia::FormatDirective(is_disable))
+        })
+    }
+
     /// Parse a line comment starting with '#'
     pub(super) fn parse_line_comment(&mut self) -> RawTrivia {
         let col = self.column;

--- a/src/lexer/cursor.rs
+++ b/src/lexer/cursor.rs
@@ -96,6 +96,30 @@ impl Lexer {
         self.column = mark.column;
     }
 
+    /// Consume `s` if it matches at the current position, advancing the cursor.
+    /// All characters in `s` must be ASCII (single-byte).
+    #[inline]
+    pub(super) fn eat_str(&mut self, s: &str) -> bool {
+        if self.at(s) {
+            // All directive strings are pure ASCII, so byte len == char count.
+            self.byte_pos += s.len();
+            self.column += s.len();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Return the remaining text on the current line without consuming it.
+    #[inline]
+    pub(super) fn peek_to_eol(&self) -> &str {
+        let bytes = self.source.as_bytes();
+        let start = self.byte_pos;
+        let end =
+            memchr::memchr2(b'\n', b'\r', &bytes[start..]).map_or(bytes.len(), |off| start + off);
+        &self.source[start..end]
+    }
+
     /// Run `f`; on `None`, rewind cursor (`byte_pos/line/column`) only.
     /// Does NOT restore `trivia_buffer`/`recent_*` — callers must not mutate
     /// those inside `f`.

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -24,6 +24,8 @@ pub enum RawTrivia {
     BlockComment(bool, Vec<String>),
     /// Language annotation like /* lua */
     LanguageAnnotation(String),
+    /// Format directive: `/*nixfmt:disable*/` (true) or `/*nixfmt:enable*/` (false)
+    FormatDirective(bool),
 }
 
 /// Cursor-only snapshot of the lexer (no heap state).
@@ -271,9 +273,9 @@ impl Lexer {
                     self.trivia_scratch.push(c);
                 }
                 Some('/') if self.at("/*") => {
-                    // try_parse_language_annotation already restores state on
-                    // failure, so no outer save/restore is needed here.
-                    if let Some(lang_annot) = self.try_parse_language_annotation() {
+                    if let Some(directive) = self.try_parse_format_directive() {
+                        self.trivia_scratch.push(directive);
+                    } else if let Some(lang_annot) = self.try_parse_language_annotation() {
                         self.trivia_scratch.push(lang_annot);
                     } else {
                         let c = self.parse_block_comment();

--- a/src/lexer/trivia.rs
+++ b/src/lexer/trivia.rs
@@ -11,7 +11,7 @@ use crate::ast::{TrailingComment, Trivia, TriviaPiece};
 /// Check if a `RawTrivia` should be classified as trailing
 const fn is_trailing(pt: &RawTrivia) -> bool {
     match pt {
-        RawTrivia::LineComment { .. } => true,
+        RawTrivia::LineComment { .. } | RawTrivia::FormatDirective(_) => true,
         RawTrivia::BlockComment(false, lines) => lines.len() <= 1,
         _ => false,
     }
@@ -26,6 +26,8 @@ fn convert_trailing(pts: &[RawTrivia]) -> Option<TrailingComment> {
             RawTrivia::BlockComment(false, lines) if lines.len() == 1 => {
                 Some(lines[0].trim().to_string())
             }
+            RawTrivia::FormatDirective(true) => Some("nixfmt:disable".to_string()),
+            RawTrivia::FormatDirective(false) => Some("nixfmt:enable".to_string()),
             _ => None,
         })
         .filter(|s| !s.is_empty())
@@ -74,6 +76,9 @@ pub(super) fn convert_leading(pts: &[RawTrivia]) -> Trivia {
                             acc.push(TriviaPiece::LanguageAnnotation(
                                 text.clone().into_boxed_str(),
                             ));
+                        }
+                        RawTrivia::FormatDirective(is_disable) => {
+                            acc.push(TriviaPiece::FormatDirective(*is_disable));
                         }
                         RawTrivia::Newlines(_) => unreachable!(),
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ mod format;
 mod lexer;
 mod normalize;
 mod parser;
+mod postprocess;
 
 pub use error::ParseError;
 
@@ -113,8 +114,8 @@ pub fn format_with(source: &str, opts: &Options) -> Result<String> {
         width: opts.width,
         indent_width: opts.indent,
     };
-    let output = doc.render(&config);
-    Ok(output)
+    let formatted = doc.render(&config);
+    Ok(postprocess::apply_directives(source, &formatted))
 }
 
 #[cfg(any(test, feature = "debug-dump"))]

--- a/src/postprocess.rs
+++ b/src/postprocess.rs
@@ -1,0 +1,225 @@
+//! Post-processing pass that splices unformatted regions back into the
+//! formatted output when `/*nixfmt:disable*/` / `/*nixfmt:enable*/`
+//! directives are present. Port of `Nixfmt.Postprocess`.
+//!
+//! Directives must be on their own line (only optional leading whitespace).
+//! Directives inside strings are ignored; directives inside `${}`
+//! interpolations are recognized (real Nix code context).
+//! An unclosed `/*nixfmt:disable*/` extends to end of file.
+
+/// Given the original source and the formatted output, find matching
+/// directive pairs in both texts and replace the formatted regions with the
+/// corresponding raw original text.
+pub fn apply_directives(original: &str, formatted: &str) -> String {
+    let formatted_lines: Vec<&str> = formatted.lines().collect();
+    let formatted_regions = find_regions(&formatted_lines);
+    if formatted_regions.is_empty() {
+        return formatted.to_owned();
+    }
+
+    let original_lines: Vec<&str> = original.lines().collect();
+    let original_regions = find_regions(&original_lines);
+
+    debug_assert_eq!(
+        original_regions.len(),
+        formatted_regions.len(),
+        "directive region count diverged between original and formatted"
+    );
+
+    let mut result = Vec::with_capacity(formatted_lines.len());
+    let mut fmt_idx = 0;
+    for (orig, fmt) in original_regions.iter().zip(&formatted_regions) {
+        let (fmt_start, fmt_end) = bounds(*fmt, formatted_lines.len());
+        let (orig_start, orig_end) = bounds(*orig, original_lines.len());
+        result.extend_from_slice(&formatted_lines[fmt_idx..fmt_start]);
+        result.extend_from_slice(&original_lines[orig_start..=orig_end]);
+        fmt_idx = fmt_end + 1;
+    }
+    result.extend_from_slice(&formatted_lines[fmt_idx..]);
+
+    let mut out = result.join("\n");
+    if formatted.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+/// Disable region: line index of `/*nixfmt:disable*/` and optionally the
+/// matching `/*nixfmt:enable*/`. `None` means unclosed (extends to EOF).
+type Region = (usize, Option<usize>);
+
+fn bounds((start, end): Region, total: usize) -> (usize, usize) {
+    (start, end.unwrap_or(total - 1))
+}
+
+/// Lexical context the scanner is currently inside.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Frame {
+    Normal,
+    String,
+    MultiString,
+    BlockComment,
+}
+
+fn find_regions(lines: &[&str]) -> Vec<Region> {
+    let mut state = vec![Frame::Normal];
+    let mut regions = Vec::new();
+    let mut open: Option<usize> = None;
+
+    for (idx, line) in lines.iter().enumerate() {
+        if matches!(state.last(), Some(Frame::Normal) | None) {
+            match line.trim() {
+                "/*nixfmt:disable*/" if open.is_none() => open = Some(idx),
+                "/*nixfmt:enable*/" => {
+                    if let Some(start) = open.take() {
+                        regions.push((start, Some(idx)));
+                    }
+                }
+                _ => {}
+            }
+        }
+        advance_state(&mut state, line.as_bytes());
+    }
+
+    if let Some(start) = open {
+        regions.push((start, None));
+    }
+    regions
+}
+
+/// Advance the context stack across one line. All delimiters are ASCII, so
+/// byte-wise scanning is safe; multi-byte UTF-8 (`>= 0x80`) never matches.
+fn advance_state(state: &mut Vec<Frame>, line: &[u8]) {
+    let mut i = 0;
+    while i < line.len() {
+        let two = (line[i], line.get(i + 1).copied());
+        match state.last().copied().unwrap_or(Frame::Normal) {
+            Frame::Normal => match two {
+                (b'#', _) => break,
+                (b'"', _) => {
+                    state.push(Frame::String);
+                    i += 1;
+                }
+                (b'\'', Some(b'\'')) => {
+                    state.push(Frame::MultiString);
+                    i += 2;
+                }
+                (b'/', Some(b'*')) => {
+                    state.push(Frame::BlockComment);
+                    i += 2;
+                }
+                (b'{', _) => {
+                    state.push(Frame::Normal);
+                    i += 1;
+                }
+                (b'}', _) => {
+                    if state.len() > 1 {
+                        state.pop();
+                    }
+                    i += 1;
+                }
+                _ => i += 1,
+            },
+            Frame::String => match two {
+                (b'\\', Some(_)) => i += 2,
+                (b'$', Some(b'{')) => {
+                    state.push(Frame::Normal);
+                    i += 2;
+                }
+                (b'"', _) => {
+                    state.pop();
+                    i += 1;
+                }
+                _ => i += 1,
+            },
+            Frame::MultiString => match two {
+                (b'\'', Some(b'\'')) => match line.get(i + 2) {
+                    Some(b'\'' | b'\\') => i += 3,
+                    Some(b'$') if line.get(i + 3) == Some(&b'{') => i += 4,
+                    _ => {
+                        state.pop();
+                        i += 2;
+                    }
+                },
+                (b'$', Some(b'{')) => {
+                    state.push(Frame::Normal);
+                    i += 2;
+                }
+                _ => i += 1,
+            },
+            Frame::BlockComment => match two {
+                (b'*', Some(b'/')) => {
+                    state.pop();
+                    i += 2;
+                }
+                _ => i += 1,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_disable_enable() {
+        let original = "{\n  a   =   1;\n/*nixfmt:disable*/\n  b    =    2;\n/*nixfmt:enable*/\n  c   =   3;\n}\n";
+        let formatted =
+            "{\n  a = 1;\n/*nixfmt:disable*/\n  b = 2;\n/*nixfmt:enable*/\n  c = 3;\n}\n";
+        let result = apply_directives(original, formatted);
+        assert!(result.contains("b    =    2;"));
+        assert!(result.contains("a = 1;"));
+        assert!(result.contains("c = 3;"));
+    }
+
+    #[test]
+    fn unclosed_disable() {
+        let original = "{\n  a = 1;\n/*nixfmt:disable*/\n  b    =    2;\n  c    =    3;\n}\n";
+        let formatted = "{\n  a = 1;\n/*nixfmt:disable*/\n  b = 2;\n  c = 3;\n}\n";
+        let result = apply_directives(original, formatted);
+        assert!(result.contains("b    =    2;"));
+        assert!(result.contains("c    =    3;"));
+    }
+
+    #[test]
+    fn no_directives_passthrough() {
+        let text = "{ foo = 1; }\n";
+        assert_eq!(apply_directives(text, text), text);
+    }
+
+    #[test]
+    fn directive_in_string_ignored() {
+        let lines = vec!["{", "  x = ''", "    /*nixfmt:disable*/", "  '';", "}"];
+        assert!(find_regions(&lines).is_empty());
+    }
+
+    #[test]
+    fn directive_in_interpolation_recognized() {
+        let lines = vec![
+            "  x = \"${",
+            "/*nixfmt:disable*/",
+            "    1 + 2",
+            "/*nixfmt:enable*/",
+            "  }\";",
+        ];
+        assert_eq!(find_regions(&lines), vec![(1, Some(3))]);
+    }
+
+    #[test]
+    fn nested_disable_ignored() {
+        let lines = vec![
+            "/*nixfmt:disable*/",
+            "/*nixfmt:disable*/",
+            "x",
+            "/*nixfmt:enable*/",
+        ];
+        assert_eq!(find_regions(&lines), vec![(0, Some(3))]);
+    }
+
+    #[test]
+    fn lone_enable_ignored() {
+        let lines = vec!["/*nixfmt:enable*/", "x"];
+        assert!(find_regions(&lines).is_empty());
+    }
+}

--- a/tests/fixtures/nixfmt/correct/directive.nix
+++ b/tests/fixtures/nixfmt/correct/directive.nix
@@ -1,0 +1,11 @@
+{
+  formatted = 1;
+
+/*nixfmt:disable*/
+  aligned    =    1;
+  table      =    2;
+  here       =    3;
+/*nixfmt:enable*/
+
+  alsoFormatted = 2;
+}

--- a/tests/fixtures/nixfmt/diff/directive_edge_cases/in.nix
+++ b/tests/fixtures/nixfmt/diff/directive_edge_cases/in.nix
@@ -1,0 +1,101 @@
+/*nixfmt:disable*/
+                      
+                      
+                      # Directive at the very start of the file 
+/*nixfmt:enable*/
+{
+  # -- Operator chains --
+  # Directive in the middle of an operator chain
+  opChain =
+    [ 1 2 3 ]
+    ++
+/*nixfmt:disable*/
+    [ 4    5    6    7    8 ]
+/*nixfmt:enable*/
+    ++   [ 9 10 ]
+  ;
+
+  # Directive in a string concatenation chain
+  strConcat =
+    "line 1"
+    +
+/*nixfmt:disable*/
+    "line   2"
+    + "line   3"
+/*nixfmt:enable*/
+    +   "line 4";
+
+  # -- List items --
+  # Aligned list items (the most common real-world use case)
+  fonts = [
+/*nixfmt:disable*/
+    "arial.ttf"        "arialbd.ttf"    "ariali.ttf"          "arialbi.ttf"     # Arial
+    "comic.ttf"        "comicbd.ttf"    "comici.ttf"          "comicz.ttf"      # Comic Sans MS
+    "consola.ttf"      "consolab.ttf"   "consolai.ttf"        "consolaz.ttf"    # Consolas
+/*nixfmt:enable*/
+  ];
+
+  # -- Blank lines --
+  # Multiple consecutive blank lines before a directive (should be collapsed)
+  beforeBlank   =   1;
+
+
+
+/*nixfmt:disable*/
+  insideBlank    =    2;
+/*nixfmt:enable*/
+
+  # Multiple consecutive blank lines inside a disabled region (preserved as-is)
+/*nixfmt:disable*/
+  a    =    1;
+
+
+
+  b    =    2;
+/*nixfmt:enable*/
+  afterBlank   =   3;
+
+  # -- Nested attribute sets --
+  # Directive spanning nested sets (force-expanded per spec)
+  nested = {
+    outer = {
+/*nixfmt:disable*/
+      inner    =    {
+        nested   =   1;
+        deep     =   2;
+      };
+/*nixfmt:enable*/
+    };
+  };
+
+  # -- Niche cases --
+
+  # Indented string with escape sequences near directive-like text.
+  # Only disable (if the scanner misreads this, the rest of the file breaks)
+  escapes = ''
+    escaped quotes: '''
+    escaped dollar: ''$
+    escaped newline: ''\n
+    /*nixfmt:disable*/
+    this is string content, not a directive
+  '';
+
+  # This MUST be formatted (proves escapes didn't confuse the scanner)
+  afterEscapes   =   1;
+
+  # Consecutive interpolations
+  multiInterp = ''${x}${y}${z}'';
+
+  # This MUST be formatted
+  afterMultiInterp   =   2;
+
+  # Directive with tabs in leading/trailing whitespace
+	/*nixfmt:disable*/
+  tabbed    =    1;
+	/*nixfmt:enable*/
+
+  # This MUST be formatted
+  afterTabbed   =   3;
+
+  last   =   99;
+}

--- a/tests/fixtures/nixfmt/diff/directive_edge_cases/out-pure.nix
+++ b/tests/fixtures/nixfmt/diff/directive_edge_cases/out-pure.nix
@@ -1,0 +1,104 @@
+/*nixfmt:disable*/
+                      
+                      
+                      # Directive at the very start of the file 
+/*nixfmt:enable*/
+{
+  # -- Operator chains --
+  # Directive in the middle of an operator chain
+  opChain = [
+    1
+    2
+    3
+  ]
+  ++
+/*nixfmt:disable*/
+    [ 4    5    6    7    8 ]
+/*nixfmt:enable*/
+  ++ [
+    9
+    10
+  ];
+
+  # Directive in a string concatenation chain
+  strConcat =
+    "line 1"
+    +
+/*nixfmt:disable*/
+    "line   2"
+    + "line   3"
+/*nixfmt:enable*/
+    + "line 4";
+
+  # -- List items --
+  # Aligned list items (the most common real-world use case)
+  fonts = [
+/*nixfmt:disable*/
+    "arial.ttf"        "arialbd.ttf"    "ariali.ttf"          "arialbi.ttf"     # Arial
+    "comic.ttf"        "comicbd.ttf"    "comici.ttf"          "comicz.ttf"      # Comic Sans MS
+    "consola.ttf"      "consolab.ttf"   "consolai.ttf"        "consolaz.ttf"    # Consolas
+/*nixfmt:enable*/
+  ];
+
+  # -- Blank lines --
+  # Multiple consecutive blank lines before a directive (should be collapsed)
+  beforeBlank = 1;
+
+/*nixfmt:disable*/
+  insideBlank    =    2;
+/*nixfmt:enable*/
+
+  # Multiple consecutive blank lines inside a disabled region (preserved as-is)
+/*nixfmt:disable*/
+  a    =    1;
+
+
+
+  b    =    2;
+/*nixfmt:enable*/
+  afterBlank = 3;
+
+  # -- Nested attribute sets --
+  # Directive spanning nested sets (force-expanded per spec)
+  nested = {
+    outer = {
+/*nixfmt:disable*/
+      inner    =    {
+        nested   =   1;
+        deep     =   2;
+      };
+/*nixfmt:enable*/
+    };
+  };
+
+  # -- Niche cases --
+
+  # Indented string with escape sequences near directive-like text.
+  # Only disable (if the scanner misreads this, the rest of the file breaks)
+  escapes = ''
+    escaped quotes: '''
+    escaped dollar: ''$
+    escaped newline: ''\n
+    /*nixfmt:disable*/
+    this is string content, not a directive
+  '';
+
+  # This MUST be formatted (proves escapes didn't confuse the scanner)
+  afterEscapes = 1;
+
+  # Consecutive interpolations
+  multiInterp = "${x}${y}${z}";
+
+  # This MUST be formatted
+  afterMultiInterp = 2;
+
+  # Directive with tabs in leading/trailing whitespace
+	/*nixfmt:disable*/
+  tabbed    =    1;
+	/*nixfmt:enable*/
+
+  # This MUST be formatted
+  afterTabbed = 3;
+
+  last = 99;
+}

--- a/tests/fixtures/nixfmt/diff/directive_edge_cases/out.nix
+++ b/tests/fixtures/nixfmt/diff/directive_edge_cases/out.nix
@@ -1,0 +1,104 @@
+/*nixfmt:disable*/
+                      
+                      
+                      # Directive at the very start of the file 
+/*nixfmt:enable*/
+{
+  # -- Operator chains --
+  # Directive in the middle of an operator chain
+  opChain = [
+    1
+    2
+    3
+  ]
+  ++
+/*nixfmt:disable*/
+    [ 4    5    6    7    8 ]
+/*nixfmt:enable*/
+  ++ [
+    9
+    10
+  ];
+
+  # Directive in a string concatenation chain
+  strConcat =
+    "line 1"
+    +
+/*nixfmt:disable*/
+    "line   2"
+    + "line   3"
+/*nixfmt:enable*/
+    + "line 4";
+
+  # -- List items --
+  # Aligned list items (the most common real-world use case)
+  fonts = [
+/*nixfmt:disable*/
+    "arial.ttf"        "arialbd.ttf"    "ariali.ttf"          "arialbi.ttf"     # Arial
+    "comic.ttf"        "comicbd.ttf"    "comici.ttf"          "comicz.ttf"      # Comic Sans MS
+    "consola.ttf"      "consolab.ttf"   "consolai.ttf"        "consolaz.ttf"    # Consolas
+/*nixfmt:enable*/
+  ];
+
+  # -- Blank lines --
+  # Multiple consecutive blank lines before a directive (should be collapsed)
+  beforeBlank = 1;
+
+/*nixfmt:disable*/
+  insideBlank    =    2;
+/*nixfmt:enable*/
+
+  # Multiple consecutive blank lines inside a disabled region (preserved as-is)
+/*nixfmt:disable*/
+  a    =    1;
+
+
+
+  b    =    2;
+/*nixfmt:enable*/
+  afterBlank = 3;
+
+  # -- Nested attribute sets --
+  # Directive spanning nested sets (force-expanded per spec)
+  nested = {
+    outer = {
+/*nixfmt:disable*/
+      inner    =    {
+        nested   =   1;
+        deep     =   2;
+      };
+/*nixfmt:enable*/
+    };
+  };
+
+  # -- Niche cases --
+
+  # Indented string with escape sequences near directive-like text.
+  # Only disable (if the scanner misreads this, the rest of the file breaks)
+  escapes = ''
+    escaped quotes: '''
+    escaped dollar: ''$
+    escaped newline: ''\n
+    /*nixfmt:disable*/
+    this is string content, not a directive
+  '';
+
+  # This MUST be formatted (proves escapes didn't confuse the scanner)
+  afterEscapes = 1;
+
+  # Consecutive interpolations
+  multiInterp = "${x}${y}${z}";
+
+  # This MUST be formatted
+  afterMultiInterp = 2;
+
+  # Directive with tabs in leading/trailing whitespace
+	/*nixfmt:disable*/
+  tabbed    =    1;
+	/*nixfmt:enable*/
+
+  # This MUST be formatted
+  afterTabbed = 3;
+
+  last = 99;
+}

--- a/tests/fixtures/nixfmt/diff/directive_multi/in.nix
+++ b/tests/fixtures/nixfmt/diff/directive_multi/in.nix
@@ -1,0 +1,78 @@
+{
+  # Region 1
+/*nixfmt:disable*/
+  foo    =    1;
+  bar    =    2;
+/*nixfmt:enable*/
+
+  # Formatted normally between regions
+  baz   =   3;
+
+  # Region 2 (adjacent — enable immediately followed by disable)
+/*nixfmt:disable*/
+  qux    =    4;
+  quux   =    5;
+/*nixfmt:enable*/
+
+  # -- False positives section --
+  # All of these contain directive-like text that must NOT be recognized.
+  # Crucially, they are NOT inside a real disable region, so if the scanner
+  # mistakenly treats them as real directives, subsequent code would break.
+
+  # Multi-line string with a lone disable (no enable) — must not start a region
+  falsePositive1 = ''
+    /*nixfmt:disable*/
+    this   is   a   string
+  '';
+
+  # This MUST be formatted (proves the string above didn't start a disabled region)
+  formatted1   =   100;
+
+  # Multi-line string with '' escape sequences near directive-like text.
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  falsePositive2 = ''
+    here's some escaped quotes: '''
+    /*nixfmt:disable*/
+    and an escaped interpolation ''${foo}
+    more text
+  '';
+
+  # This MUST be formatted
+  formatted2   =   200;
+
+  # Directive inside a regular string spanning multiple lines
+  falsePositive3 = "
+/*nixfmt:disable*/
+  not   a   directive
+";
+
+  # This MUST be formatted
+  formatted3   =   300;
+
+  # -- Ignored directives --
+  # Directives that share a line with other code must be ignored.
+
+  # Trailing on a code line — just a comment, not a directive
+  ignored1   =   1; /*nixfmt:disable*/
+  ignored2   =   2;
+
+  # Directive with extra text after */ — not a valid directive
+  /*nixfmt:disable*/ ignoredInline   =   3;
+
+  # -- Consecutive directives --
+  # Consecutive disables: second one is ignored (already disabled)
+/*nixfmt:disable*/
+/*nixfmt:disable*/
+  alpha    =    10;
+  beta     =    20;
+/*nixfmt:enable*/
+
+  # Consecutive enables: second one is ignored (already enabled)
+/*nixfmt:disable*/
+  gamma    =    30;
+/*nixfmt:enable*/
+/*nixfmt:enable*/
+
+  # This MUST be formatted
+  last   =   6;
+}

--- a/tests/fixtures/nixfmt/diff/directive_multi/out-pure.nix
+++ b/tests/fixtures/nixfmt/diff/directive_multi/out-pure.nix
@@ -1,0 +1,79 @@
+{
+  # Region 1
+/*nixfmt:disable*/
+  foo    =    1;
+  bar    =    2;
+/*nixfmt:enable*/
+
+  # Formatted normally between regions
+  baz = 3;
+
+  # Region 2 (adjacent — enable immediately followed by disable)
+/*nixfmt:disable*/
+  qux    =    4;
+  quux   =    5;
+/*nixfmt:enable*/
+
+  # -- False positives section --
+  # All of these contain directive-like text that must NOT be recognized.
+  # Crucially, they are NOT inside a real disable region, so if the scanner
+  # mistakenly treats them as real directives, subsequent code would break.
+
+  # Multi-line string with a lone disable (no enable) — must not start a region
+  falsePositive1 = ''
+    /*nixfmt:disable*/
+    this   is   a   string
+  '';
+
+  # This MUST be formatted (proves the string above didn't start a disabled region)
+  formatted1 = 100;
+
+  # Multi-line string with '' escape sequences near directive-like text.
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  falsePositive2 = ''
+    here's some escaped quotes: '''
+    /*nixfmt:disable*/
+    and an escaped interpolation ''${foo}
+    more text
+  '';
+
+  # This MUST be formatted
+  formatted2 = 200;
+
+  # Directive inside a regular string spanning multiple lines
+  falsePositive3 = "
+/*nixfmt:disable*/
+  not   a   directive
+";
+
+  # This MUST be formatted
+  formatted3 = 300;
+
+  # -- Ignored directives --
+  # Directives that share a line with other code must be ignored.
+
+  # Trailing on a code line — just a comment, not a directive
+  ignored1 = 1; # nixfmt:disable
+  ignored2 = 2;
+
+  # Directive with extra text after */ — not a valid directive
+  # nixfmt:disable
+  ignoredInline = 3;
+
+  # -- Consecutive directives --
+  # Consecutive disables: second one is ignored (already disabled)
+/*nixfmt:disable*/
+/*nixfmt:disable*/
+  alpha    =    10;
+  beta     =    20;
+/*nixfmt:enable*/
+
+  # Consecutive enables: second one is ignored (already enabled)
+/*nixfmt:disable*/
+  gamma    =    30;
+/*nixfmt:enable*/
+  /*nixfmt:enable*/
+
+  # This MUST be formatted
+  last = 6;
+}

--- a/tests/fixtures/nixfmt/diff/directive_multi/out.nix
+++ b/tests/fixtures/nixfmt/diff/directive_multi/out.nix
@@ -1,0 +1,79 @@
+{
+  # Region 1
+/*nixfmt:disable*/
+  foo    =    1;
+  bar    =    2;
+/*nixfmt:enable*/
+
+  # Formatted normally between regions
+  baz = 3;
+
+  # Region 2 (adjacent — enable immediately followed by disable)
+/*nixfmt:disable*/
+  qux    =    4;
+  quux   =    5;
+/*nixfmt:enable*/
+
+  # -- False positives section --
+  # All of these contain directive-like text that must NOT be recognized.
+  # Crucially, they are NOT inside a real disable region, so if the scanner
+  # mistakenly treats them as real directives, subsequent code would break.
+
+  # Multi-line string with a lone disable (no enable) — must not start a region
+  falsePositive1 = ''
+    /*nixfmt:disable*/
+    this   is   a   string
+  '';
+
+  # This MUST be formatted (proves the string above didn't start a disabled region)
+  formatted1 = 100;
+
+  # Multi-line string with '' escape sequences near directive-like text.
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  falsePositive2 = ''
+    here's some escaped quotes: '''
+    /*nixfmt:disable*/
+    and an escaped interpolation ''${foo}
+    more text
+  '';
+
+  # This MUST be formatted
+  formatted2 = 200;
+
+  # Directive inside a regular string spanning multiple lines
+  falsePositive3 = "
+/*nixfmt:disable*/
+  not   a   directive
+";
+
+  # This MUST be formatted
+  formatted3 = 300;
+
+  # -- Ignored directives --
+  # Directives that share a line with other code must be ignored.
+
+  # Trailing on a code line — just a comment, not a directive
+  ignored1 = 1; # nixfmt:disable
+  ignored2 = 2;
+
+  # Directive with extra text after */ — not a valid directive
+  # nixfmt:disable
+  ignoredInline = 3;
+
+  # -- Consecutive directives --
+  # Consecutive disables: second one is ignored (already disabled)
+/*nixfmt:disable*/
+/*nixfmt:disable*/
+  alpha    =    10;
+  beta     =    20;
+/*nixfmt:enable*/
+
+  # Consecutive enables: second one is ignored (already enabled)
+/*nixfmt:disable*/
+  gamma    =    30;
+/*nixfmt:enable*/
+  /*nixfmt:enable*/
+
+  # This MUST be formatted
+  last = 6;
+}

--- a/tests/fixtures/nixfmt/diff/directive_positions/in.nix
+++ b/tests/fixtures/nixfmt/diff/directive_positions/in.nix
@@ -1,0 +1,83 @@
+{
+  # Indented directive inside an attrset
+  nested = {
+    /*nixfmt:disable*/
+    foo    =    1;
+    bar    =    2;
+    /*nixfmt:enable*/
+    baz   =   3;
+  };
+
+  # Directive inside a let binding
+  letExample = let
+    /*nixfmt:disable*/
+    x    =    1;
+    y    =    2;
+    /*nixfmt:enable*/
+    z   =   3;
+  in
+    x;
+
+  # Directive after a comment block
+  # some comment
+  /*nixfmt:disable*/
+  commented    =    1;
+  /*nixfmt:enable*/
+
+  # Directive right after opening brace (own line)
+  afterBrace = {
+    /*nixfmt:disable*/
+    a    =    1;
+    b    =    2;
+    /*nixfmt:enable*/
+  };
+
+  # Directive right after opening bracket (own line)
+  afterBracket = [
+    /*nixfmt:disable*/
+    "a"    "b"    "c"
+    /*nixfmt:enable*/
+  ];
+
+  # -- Trailing position --
+  # Directives sharing a line with other tokens are not on their own line,
+  # so they are treated as regular comments and ignored.
+
+  # Trailing on [
+  trailingBracket = [  /*nixfmt:disable*/
+    "x"    "y"    "z"
+    /*nixfmt:enable*/
+  ];
+
+  # Trailing on {
+  trailingBrace = {  /*nixfmt:disable*/
+    c    =    1;
+    d    =    2;
+    /*nixfmt:enable*/
+  };
+
+  # Trailing on (
+  trailingParen = (  /*nixfmt:disable*/
+    1   +   2
+  );
+
+  # Trailing on in
+  trailingIn = let
+    x = 1;
+  in  /*nixfmt:disable*/
+    x      ;
+
+  # -- Language annotation disambiguation --
+  # /*nixfmt:disable*/ before a string must NOT be confused with a language annotation.
+
+  # Directive before a string — ignored (trailing position), not a lang annotation
+  notLangAnnotation = /*nixfmt:disable*/ "hello";
+
+  # Real language annotation still works normally
+  langAnnotation = /* lua */ "print(1)";
+
+  # Directive on own line, followed by a language annotation inside disabled region
+/*nixfmt:disable*/
+  preservedLangAnnotation = /* lua */    "print(2)"   ;
+/*nixfmt:enable*/
+}

--- a/tests/fixtures/nixfmt/diff/directive_positions/out-pure.nix
+++ b/tests/fixtures/nixfmt/diff/directive_positions/out-pure.nix
@@ -1,0 +1,92 @@
+{
+  # Indented directive inside an attrset
+  nested = {
+    /*nixfmt:disable*/
+    foo    =    1;
+    bar    =    2;
+    /*nixfmt:enable*/
+    baz = 3;
+  };
+
+  # Directive inside a let binding
+  letExample =
+    let
+    /*nixfmt:disable*/
+    x    =    1;
+    y    =    2;
+    /*nixfmt:enable*/
+      z = 3;
+    in
+    x;
+
+  # Directive after a comment block
+  # some comment
+  /*nixfmt:disable*/
+  commented    =    1;
+  /*nixfmt:enable*/
+
+  # Directive right after opening brace (own line)
+  afterBrace = {
+    /*nixfmt:disable*/
+    a    =    1;
+    b    =    2;
+    /*nixfmt:enable*/
+  };
+
+  # Directive right after opening bracket (own line)
+  afterBracket = [
+    /*nixfmt:disable*/
+    "a"    "b"    "c"
+    /*nixfmt:enable*/
+  ];
+
+  # -- Trailing position --
+  # Directives sharing a line with other tokens are not on their own line,
+  # so they are treated as regular comments and ignored.
+
+  # Trailing on [
+  trailingBracket = [
+    # nixfmt:disable
+    "x"
+    "y"
+    "z"
+    /*nixfmt:enable*/
+  ];
+
+  # Trailing on {
+  trailingBrace = {
+    # nixfmt:disable
+    c = 1;
+    d = 2;
+    /*nixfmt:enable*/
+  };
+
+  # Trailing on (
+  trailingParen = (
+    # nixfmt:disable
+    1 + 2
+  );
+
+  # Trailing on in
+  trailingIn =
+    let
+      x = 1;
+    in
+    # nixfmt:disable
+    x;
+
+  # -- Language annotation disambiguation --
+  # /*nixfmt:disable*/ before a string must NOT be confused with a language annotation.
+
+  # Directive before a string — ignored (trailing position), not a lang annotation
+  notLangAnnotation = # nixfmt:disable
+    "hello";
+
+  # Real language annotation still works normally
+  langAnnotation = /* lua */ "print(1)";
+
+  # Directive on own line, followed by a language annotation inside disabled region
+/*nixfmt:disable*/
+  preservedLangAnnotation = /* lua */    "print(2)"   ;
+/*nixfmt:enable*/
+}

--- a/tests/fixtures/nixfmt/diff/directive_positions/out.nix
+++ b/tests/fixtures/nixfmt/diff/directive_positions/out.nix
@@ -1,0 +1,92 @@
+{
+  # Indented directive inside an attrset
+  nested = {
+    /*nixfmt:disable*/
+    foo    =    1;
+    bar    =    2;
+    /*nixfmt:enable*/
+    baz = 3;
+  };
+
+  # Directive inside a let binding
+  letExample =
+    let
+    /*nixfmt:disable*/
+    x    =    1;
+    y    =    2;
+    /*nixfmt:enable*/
+      z = 3;
+    in
+    x;
+
+  # Directive after a comment block
+  # some comment
+  /*nixfmt:disable*/
+  commented    =    1;
+  /*nixfmt:enable*/
+
+  # Directive right after opening brace (own line)
+  afterBrace = {
+    /*nixfmt:disable*/
+    a    =    1;
+    b    =    2;
+    /*nixfmt:enable*/
+  };
+
+  # Directive right after opening bracket (own line)
+  afterBracket = [
+    /*nixfmt:disable*/
+    "a"    "b"    "c"
+    /*nixfmt:enable*/
+  ];
+
+  # -- Trailing position --
+  # Directives sharing a line with other tokens are not on their own line,
+  # so they are treated as regular comments and ignored.
+
+  # Trailing on [
+  trailingBracket = [
+    # nixfmt:disable
+    "x"
+    "y"
+    "z"
+    /*nixfmt:enable*/
+  ];
+
+  # Trailing on {
+  trailingBrace = {
+    # nixfmt:disable
+    c = 1;
+    d = 2;
+    /*nixfmt:enable*/
+  };
+
+  # Trailing on (
+  trailingParen = (
+    # nixfmt:disable
+    1 + 2
+  );
+
+  # Trailing on in
+  trailingIn =
+    let
+      x = 1;
+    in
+    # nixfmt:disable
+    x;
+
+  # -- Language annotation disambiguation --
+  # /*nixfmt:disable*/ before a string must NOT be confused with a language annotation.
+
+  # Directive before a string — ignored (trailing position), not a lang annotation
+  notLangAnnotation = # nixfmt:disable
+    "hello";
+
+  # Real language annotation still works normally
+  langAnnotation = /* lua */ "print(1)";
+
+  # Directive on own line, followed by a language annotation inside disabled region
+/*nixfmt:disable*/
+  preservedLangAnnotation = /* lua */    "print(2)"   ;
+/*nixfmt:enable*/
+}

--- a/tests/fixtures/nixfmt/diff/directive_preserve/in.nix
+++ b/tests/fixtures/nixfmt/diff/directive_preserve/in.nix
@@ -1,0 +1,8 @@
+{
+/*nixfmt:disable*/
+  foo    =    1;
+  bar    =    2;
+  baz    =    3;
+/*nixfmt:enable*/
+  qux   =   4;
+}

--- a/tests/fixtures/nixfmt/diff/directive_preserve/out-pure.nix
+++ b/tests/fixtures/nixfmt/diff/directive_preserve/out-pure.nix
@@ -1,0 +1,8 @@
+{
+/*nixfmt:disable*/
+  foo    =    1;
+  bar    =    2;
+  baz    =    3;
+/*nixfmt:enable*/
+  qux = 4;
+}

--- a/tests/fixtures/nixfmt/diff/directive_preserve/out.nix
+++ b/tests/fixtures/nixfmt/diff/directive_preserve/out.nix
@@ -1,0 +1,8 @@
+{
+/*nixfmt:disable*/
+  foo    =    1;
+  bar    =    2;
+  baz    =    3;
+/*nixfmt:enable*/
+  qux = 4;
+}

--- a/tests/fixtures/nixfmt/diff/directive_string/in.nix
+++ b/tests/fixtures/nixfmt/diff/directive_string/in.nix
@@ -1,0 +1,136 @@
+{
+  # Directive in string content (not an interpolation) — must be ignored.
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  stringContent = ''
+    content
+    /*nixfmt:disable*/
+    this is just a string
+    more content
+  '';
+
+  # This MUST be formatted (proves the string directive was ignored)
+  afterString   =   1;
+
+  # Code inside interpolation is formatted normally
+  withInterpolation = ''
+    text
+    ${
+       1
+         + 2
+    }
+  '';
+
+  # -- Regular (double-quoted) strings --
+
+  # Directive inside regular string content must be ignored.
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  regularStringContent = "
+    /*nixfmt:disable*/
+    not a directive
+  ";
+
+  # This MUST be formatted
+  afterRegularString   =   10;
+
+  # Regular string with interpolation
+  regularInterp = "hello ${   1   +   2   } world";
+
+  # -- Nested interpolations --
+
+  # Regular string inside indented string interpolation
+  nestedRegularInMulti = ''
+    prefix ${   "inner   ${   1   +   2   }   value"   } suffix
+  '';
+
+  # Indented string inside regular string interpolation
+  nestedMultiInRegular = "${   ''
+    multi
+    line
+    content
+  ''   +   "x"   }";
+
+  # Deeply nested: string in interpolation in string in interpolation
+  deeplyNested = ''
+    a ${ "b ${ ''
+      c ${   1   +   2   }
+    ''   }" }
+  '';
+
+  # This MUST be formatted
+  afterNested   =   20;
+
+  # -- Directives with nested string interpolations --
+
+  # Directive inside a nested interpolation (real Nix code context)
+  directiveInNestedInterp = ''
+    outer ${
+      "inner ${
+        ''
+          deep ${
+/*nixfmt:disable*/
+            1    +    2    +    3
+/*nixfmt:enable*/
+          }
+        ''
+      }"
+    }
+  '';
+
+  # This MUST be formatted
+  afterDirectiveNested   =   30;
+
+  # Directive in regular string interpolation
+  directiveInRegularInterp = "${
+/*nixfmt:disable*/
+    1    +    2
+/*nixfmt:enable*/
+  }";
+
+  # This MUST be formatted
+  afterDirectiveRegular   =   40;
+
+  # False positive: directive-like text in nested string content (not in code position).
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  falsePositiveNested = ''
+    ${ "
+      /*nixfmt:disable*/
+      not a real directive
+    " }
+  '';
+
+  # This MUST be formatted
+  afterFalsePositive   =   50;
+
+  # Directive inside interpolation
+  # The disable has no matching enable inside the interpolation,
+  # so it disables formatting for the rest of the file.
+  withDirectiveInInterpolation = ''
+    prefix
+    ${
+       1
+         + 2
+
+/*nixfmt:disable*/
+  # from now on, formatting is disabled
+       + 
+         3
+           + 
+             4 /*nixfmt:enable*/
+                } /*nixfmt:enable*/
+                                    still disabled, because both enable directives above are invalid
+                '';
+
+  # NOT formatted (we're still in the disabled region from the interpolation above)
+  stillDisabled   =   1;
+
+  # Directive inside another interpolation to re-enable formatting
+  reEnable = ''
+    ${
+/*nixfmt:enable*/
+      1   +   2
+    }
+  '';
+
+  # This MUST be formatted (proves the enable inside interpolation worked)
+  afterEnable   =   3;
+}

--- a/tests/fixtures/nixfmt/diff/directive_string/out-pure.nix
+++ b/tests/fixtures/nixfmt/diff/directive_string/out-pure.nix
@@ -1,0 +1,132 @@
+{
+  # Directive in string content (not an interpolation) — must be ignored.
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  stringContent = ''
+    content
+    /*nixfmt:disable*/
+    this is just a string
+    more content
+  '';
+
+  # This MUST be formatted (proves the string directive was ignored)
+  afterString = 1;
+
+  # Code inside interpolation is formatted normally
+  withInterpolation = ''
+    text
+    ${1 + 2}
+  '';
+
+  # -- Regular (double-quoted) strings --
+
+  # Directive inside regular string content must be ignored.
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  regularStringContent = "
+    /*nixfmt:disable*/
+    not a directive
+  ";
+
+  # This MUST be formatted
+  afterRegularString = 10;
+
+  # Regular string with interpolation
+  regularInterp = "hello ${1 + 2} world";
+
+  # -- Nested interpolations --
+
+  # Regular string inside indented string interpolation
+  nestedRegularInMulti = ''
+    prefix ${"inner   ${1 + 2}   value"} suffix
+  '';
+
+  # Indented string inside regular string interpolation
+  nestedMultiInRegular = "${
+    ''
+      multi
+      line
+      content
+    ''
+    + "x"
+  }";
+
+  # Deeply nested: string in interpolation in string in interpolation
+  deeplyNested = ''
+    a ${"b ${''
+      c ${1 + 2}
+    ''}"}
+  '';
+
+  # This MUST be formatted
+  afterNested = 20;
+
+  # -- Directives with nested string interpolations --
+
+  # Directive inside a nested interpolation (real Nix code context)
+  directiveInNestedInterp = ''
+    outer ${"inner ${''
+      deep ${
+/*nixfmt:disable*/
+            1    +    2    +    3
+/*nixfmt:enable*/
+      }
+    ''}"}
+  '';
+
+  # This MUST be formatted
+  afterDirectiveNested = 30;
+
+  # Directive in regular string interpolation
+  directiveInRegularInterp = "${
+/*nixfmt:disable*/
+    1    +    2
+/*nixfmt:enable*/
+  }";
+
+  # This MUST be formatted
+  afterDirectiveRegular = 40;
+
+  # False positive: directive-like text in nested string content (not in code position).
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  falsePositiveNested = ''
+    ${"
+      /*nixfmt:disable*/
+      not a real directive
+    "}
+  '';
+
+  # This MUST be formatted
+  afterFalsePositive = 50;
+
+  # Directive inside interpolation
+  # The disable has no matching enable inside the interpolation,
+  # so it disables formatting for the rest of the file.
+  withDirectiveInInterpolation = ''
+    prefix
+    ${
+      1
+      + 2
+
+/*nixfmt:disable*/
+  # from now on, formatting is disabled
+       + 
+         3
+           + 
+             4 /*nixfmt:enable*/
+                } /*nixfmt:enable*/
+                                    still disabled, because both enable directives above are invalid
+                '';
+
+  # NOT formatted (we're still in the disabled region from the interpolation above)
+  stillDisabled   =   1;
+
+  # Directive inside another interpolation to re-enable formatting
+  reEnable = ''
+    ${
+/*nixfmt:enable*/
+      1 + 2
+    }
+  '';
+
+  # This MUST be formatted (proves the enable inside interpolation worked)
+  afterEnable = 3;
+}

--- a/tests/fixtures/nixfmt/diff/directive_string/out.nix
+++ b/tests/fixtures/nixfmt/diff/directive_string/out.nix
@@ -1,0 +1,132 @@
+{
+  # Directive in string content (not an interpolation) — must be ignored.
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  stringContent = ''
+    content
+    /*nixfmt:disable*/
+    this is just a string
+    more content
+  '';
+
+  # This MUST be formatted (proves the string directive was ignored)
+  afterString = 1;
+
+  # Code inside interpolation is formatted normally
+  withInterpolation = ''
+    text
+    ${1 + 2}
+  '';
+
+  # -- Regular (double-quoted) strings --
+
+  # Directive inside regular string content must be ignored.
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  regularStringContent = "
+    /*nixfmt:disable*/
+    not a directive
+  ";
+
+  # This MUST be formatted
+  afterRegularString = 10;
+
+  # Regular string with interpolation
+  regularInterp = "hello ${1 + 2} world";
+
+  # -- Nested interpolations --
+
+  # Regular string inside indented string interpolation
+  nestedRegularInMulti = ''
+    prefix ${"inner   ${1 + 2}   value"} suffix
+  '';
+
+  # Indented string inside regular string interpolation
+  nestedMultiInRegular = "${
+    ''
+      multi
+      line
+      content
+    ''
+    + "x"
+  }";
+
+  # Deeply nested: string in interpolation in string in interpolation
+  deeplyNested = ''
+    a ${"b ${''
+      c ${1 + 2}
+    ''}"}
+  '';
+
+  # This MUST be formatted
+  afterNested = 20;
+
+  # -- Directives with nested string interpolations --
+
+  # Directive inside a nested interpolation (real Nix code context)
+  directiveInNestedInterp = ''
+    outer ${"inner ${''
+      deep ${
+/*nixfmt:disable*/
+            1    +    2    +    3
+/*nixfmt:enable*/
+      }
+    ''}"}
+  '';
+
+  # This MUST be formatted
+  afterDirectiveNested = 30;
+
+  # Directive in regular string interpolation
+  directiveInRegularInterp = "${
+/*nixfmt:disable*/
+    1    +    2
+/*nixfmt:enable*/
+  }";
+
+  # This MUST be formatted
+  afterDirectiveRegular = 40;
+
+  # False positive: directive-like text in nested string content (not in code position).
+  # Only disable (no enable) — if the scanner misreads this, the rest of the file breaks.
+  falsePositiveNested = ''
+    ${"
+      /*nixfmt:disable*/
+      not a real directive
+    "}
+  '';
+
+  # This MUST be formatted
+  afterFalsePositive = 50;
+
+  # Directive inside interpolation
+  # The disable has no matching enable inside the interpolation,
+  # so it disables formatting for the rest of the file.
+  withDirectiveInInterpolation = ''
+    prefix
+    ${
+      1
+      + 2
+
+/*nixfmt:disable*/
+  # from now on, formatting is disabled
+       + 
+         3
+           + 
+             4 /*nixfmt:enable*/
+                } /*nixfmt:enable*/
+                                    still disabled, because both enable directives above are invalid
+                '';
+
+  # NOT formatted (we're still in the disabled region from the interpolation above)
+  stillDisabled   =   1;
+
+  # Directive inside another interpolation to re-enable formatting
+  reEnable = ''
+    ${
+/*nixfmt:enable*/
+      1 + 2
+    }
+  '';
+
+  # This MUST be formatted (proves the enable inside interpolation worked)
+  afterEnable = 3;
+}

--- a/tests/fixtures/nixfmt/diff/directive_unclosed/in.nix
+++ b/tests/fixtures/nixfmt/diff/directive_unclosed/in.nix
@@ -1,0 +1,6 @@
+{
+  foo   =   1;
+/*nixfmt:disable*/
+  bar    =    2;
+  baz    =    3;
+}

--- a/tests/fixtures/nixfmt/diff/directive_unclosed/out-pure.nix
+++ b/tests/fixtures/nixfmt/diff/directive_unclosed/out-pure.nix
@@ -1,0 +1,6 @@
+{
+  foo = 1;
+/*nixfmt:disable*/
+  bar    =    2;
+  baz    =    3;
+}

--- a/tests/fixtures/nixfmt/diff/directive_unclosed/out.nix
+++ b/tests/fixtures/nixfmt/diff/directive_unclosed/out.nix
@@ -1,0 +1,6 @@
+{
+  foo = 1;
+/*nixfmt:disable*/
+  bar    =    2;
+  baz    =    3;
+}


### PR DESCRIPTION

Port of upstream https://github.com/NixOS/nixfmt/pull/388. Wrapping a region in these block
comments keeps it unformatted (e.g. hand-aligned tables). Directives
must be on their own line; an unclosed disable extends to EOF.

The lexer/pretty-printer carry directives through unchanged; a
post-processing pass (src/postprocess.rs) finds matching directive
pairs in original and formatted text and splices the original lines
back in. Trailing-position directives demote to # comments so they
never affect region matching.

Verified byte-identical (output, --ast, --ir) against the Haskell PR
on all directive fixtures and the 15k-file fuzz corpus.
