### PR TITLE
lexer: lex <...> as search path only on full SPATH match

### DIFF
--- a/src/lexer/scan.rs
+++ b/src/lexer/scan.rs
@@ -43,8 +43,10 @@ impl Lexer {
             '*' => Ok(self.single(Token::Mul)),
             '/' => Ok(self.try_two_char('/', Token::Update, Token::Div)),
             '!' => Ok(self.try_two_char('=', Token::Unequal, Token::Not)),
-            '<' if self.peek_ahead(1).is_some_and(char::is_alphanumeric) => self.parse_env_path(),
             '<' => {
+                if let Some(tok) = self.try_env_path() {
+                    return Ok(tok);
+                }
                 self.advance();
                 Ok(match self.peek() {
                     Some('=') => self.single(Token::LessEqual),
@@ -148,40 +150,34 @@ impl Lexer {
         }
     }
 
-    /// Parse angle bracket path: <nixpkgs>
-    fn parse_env_path(&mut self) -> crate::error::Result<Token> {
-        let opening_span = self.current_pos();
-        self.advance(); // consume '<'
-
-        let mut path = String::new();
-        while let Some(ch) = self.peek() {
-            match ch {
-                '>' => {
-                    self.advance();
-                    return Ok(Token::EnvPath(path.into()));
-                }
-                _ if ch.is_alphanumeric() || matches!(ch, '_' | '-' | '/' | '.') => {
-                    path.push(self.advance().unwrap());
-                }
-                _ => {
-                    return Err(crate::error::ParseError {
-                        span: self.current_pos(),
-                        kind: crate::error::ErrorKind::InvalidSyntax {
-                            description: format!("invalid character '{ch}' in path"),
-                            hint: Some("paths can only contain alphanumeric characters, '.', '_', '-', and '/'".to_string()),
-                        },
-                    });
-                }
+    /// Lex a search path (`<nixpkgs/lib>`) only if the full Nix SPATH pattern
+    /// `<{PATH_CHAR}+(/{PATH_CHAR}+)*>` matches at the cursor; otherwise
+    /// consume nothing so `<` lexes as `Less`, matching the Nix lexer's
+    /// maximal-munch behaviour (`a<b` is a comparison).
+    fn try_env_path(&mut self) -> Option<Token> {
+        let is_path_char =
+            |b: u8| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-' | b'+');
+        let bytes = &self.source.as_bytes()[self.byte_pos + 1..];
+        let mut i = 0;
+        loop {
+            let seg_start = i;
+            while i < bytes.len() && is_path_char(bytes[i]) {
+                i += 1;
+            }
+            if i == seg_start {
+                return None; // empty segment, e.g. `<>` or `<a//b>`
+            }
+            match bytes.get(i) {
+                Some(b'>') => break,
+                Some(b'/') => i += 1,
+                _ => return None,
             }
         }
-
-        Err(crate::error::ParseError {
-            span: self.current_pos(),
-            kind: crate::error::ErrorKind::UnclosedDelimiter {
-                delimiter: '<',
-                opening_span,
-            },
-        })
+        let path = &self.source[self.byte_pos + 1..self.byte_pos + 1 + i];
+        let tok = Token::EnvPath(path.into());
+        // `<` + path + `>` is all ASCII with no newlines.
+        self.advance_bytes_no_newline(i + 2);
+        Some(tok)
     }
 
     /// Build an `UnexpectedToken` error at the current cursor.

--- a/src/regression_tests/format.rs
+++ b/src/regression_tests/format.rs
@@ -227,6 +227,18 @@ fn format_interp_inline_short_forced_compact() {
     test_ir_format!("''\n  prefix ${lib.makeBinPath [ gdb ]} suffix\n''");
 }
 
+/// `<` lexes as a search path only when the full Nix SPATH pattern
+/// `<{PATH_CHAR}+(/{PATH_CHAR}+)*>` matches; otherwise it is `Less`.
+/// <https://github.com/Mic92/nixfmt-rs/issues/88>
+#[test]
+fn format_less_than_without_space_not_env_path() {
+    test_format!("let a = 1; b = 2; in a<b");
+    // `a<b>c` is `a <b> c` (SPATH wins), not a comparison chain.
+    test_format!("a<b>c");
+    test_format!("<foo+bar/baz.nix>");
+    test_format!("<.foo>");
+}
+
 /// Non-chainable comparison operators (`<`, `>`, `<=`, `>=`, `==`, `!=`) use
 /// `softline` before the operator and `hardspace` after, with no extra `nest`
 /// on the RHS, so a short RHS stays on the LHS's last line even when the LHS

--- a/src/regression_tests/parser.rs
+++ b/src/regression_tests/parser.rs
@@ -300,6 +300,15 @@ fn regression_comparison_chain_should_fail() {
     assert_parse_rejected("a == b == c");
 }
 
+/// Incomplete `<path>` forms lex as `Less` and are then rejected by the
+/// parser, as in Nix and Haskell nixfmt.
+#[test]
+fn regression_incomplete_env_path_rejected() {
+    assert_parse_rejected("[ a <b ]");
+    assert_parse_rejected("<a//b>");
+    assert_parse_rejected("<>");
+}
+
 #[test]
 fn regression_path_trailing_slash_current() {
     assert_parse_rejected("./");

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_less_than_without_space_not_env_path-2.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_less_than_without_space_not_env_path-2.snap
@@ -1,0 +1,5 @@
+---
+source: src/regression_tests/format.rs
+description: a<b>c
+---
+a <b> c

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_less_than_without_space_not_env_path-3.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_less_than_without_space_not_env_path-3.snap
@@ -1,0 +1,5 @@
+---
+source: src/regression_tests/format.rs
+description: "<foo+bar/baz.nix>"
+---
+<foo+bar/baz.nix>

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_less_than_without_space_not_env_path-4.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_less_than_without_space_not_env_path-4.snap
@@ -1,0 +1,5 @@
+---
+source: src/regression_tests/format.rs
+description: "<.foo>"
+---
+<.foo>

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_less_than_without_space_not_env_path.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_less_than_without_space_not_env_path.snap
@@ -1,0 +1,9 @@
+---
+source: src/regression_tests/format.rs
+description: let a = 1; b = 2; in a<b
+---
+let
+  a = 1;
+  b = 2;
+in
+a < b


### PR DESCRIPTION
The lexer committed to a search path as soon as it saw '<' followed by an alphanumeric character, so valid expressions like 'a<b' failed to parse. Match Nix's maximal-munch SPATH rule: look ahead for the complete <{PATH_CHAR}+(/{PATH_CHAR}+)*> pattern and fall back to Less otherwise. Also fixes the character set ('+' was rejected, Unicode and '//' accepted).

Fixes https://github.com/Mic92/nixfmt-rs/issues/88