### PR TITLE
ci: auto-sync wasm-bindgen crate pin on nixpkgs bumps

### DIFF
--- a/.github/workflows/sync-wasm-bindgen.yml
+++ b/.github/workflows/sync-wasm-bindgen.yml
@@ -1,0 +1,37 @@
+name: Sync wasm-bindgen pin with nixpkgs
+
+# wasm-bindgen crate and wasm-bindgen-cli must be the same version.
+# Nixpkgs bumps the CLI; this keeps the crate pin in sync.
+
+on:
+  pull_request_target:
+    paths:
+      - "flake.lock"
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: NixOS/nix-installer-action@main
+
+      - name: Sync wasm-bindgen version
+        env:
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          ./scripts/sync-wasm-bindgen.sh
+          git diff --quiet && exit 0
+          git add wasm/Cargo.toml Cargo.lock
+          git commit -m "wasm: sync wasm-bindgen pin to $(sed -n 's/^wasm-bindgen = "=\(.*\)"/\1/p' wasm/Cargo.toml)"
+          git push

--- a/scripts/sync-wasm-bindgen.sh
+++ b/scripts/sync-wasm-bindgen.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Sync the wasm-bindgen crate pin in wasm/Cargo.toml with
+# the wasm-bindgen-cli version from nixpkgs.
+set -euo pipefail
+
+cli=$(nix eval --inputs-from . --raw 'nixpkgs#wasm-bindgen-cli.version')
+pinned=$(sed -n 's/^wasm-bindgen = "=\(.*\)"/\1/p' wasm/Cargo.toml)
+
+if [ "$cli" = "$pinned" ]; then
+  echo "wasm-bindgen already at $cli"
+  exit 0
+fi
+
+echo "Updating wasm-bindgen: $pinned -> $cli"
+sed -i "s/^wasm-bindgen = \"=.*\"/wasm-bindgen = \"=$cli\"/" wasm/Cargo.toml
+cargo update -p wasm-bindgen --precise "$cli"


### PR DESCRIPTION
Add a GitHub Action that detects the mismatch on dependabot PRs and pushes a fixup commit.