### PR TITLE
parser: require commas between set-pattern formals

### DIFF
--- a/src/parser/parameters.rs
+++ b/src/parser/parameters.rs
@@ -136,10 +136,7 @@ impl Parser {
                     .transpose()?;
 
                 let needs_break = comma.is_none()
-                    && !matches!(
-                        self.current.value,
-                        Token::BraceClose | Token::Ellipsis | Token::Sof
-                    );
+                    && !matches!(self.current.value, Token::BraceClose | Token::Sof);
 
                 attrs.push(ParamAttr::Attr {
                     name,

--- a/src/parser/path_uri.rs
+++ b/src/parser/path_uri.rs
@@ -205,8 +205,10 @@ impl Parser {
                 _ => false,
             },
 
-            // ./ or .<pathchars>/ — Nix treats `.foo/bar` the same as
-            // `./foo/bar`; `../` is the case where the path char is `.`.
+            // ./ or ..<pathchars>/ (no space before the tail, else
+            // `.\n/c` becomes `./c`).  Nix treats `.foo/bar` as a
+            // relative path just like `./foo/bar`; `../bar` is the
+            // special case where the path chars are a single `.`.
             Token::Dot if !self.has_preceding_whitespace() => match self.lexer.peek() {
                 Some('/') => self.is_path_content_at(1),
                 Some(c) if is_path_char(c) => {

--- a/src/regression_tests/parser.rs
+++ b/src/regression_tests/parser.rs
@@ -363,6 +363,15 @@ fn regression_tilde_not_path_char() {
     assert!(crate::parse("~/a").is_ok());
 }
 
+/// Ellipsis after a formal requires a preceding comma.
+#[test]
+fn regression_ellipsis_requires_comma() {
+    assert_parse_rejected("{ a ... }: a");
+    assert_parse_rejected("{ b ? 1 ... }: b");
+    assert!(crate::parse("{ a, ... }: a").is_ok());
+    assert!(crate::parse("{ ... }: 1").is_ok());
+}
+
 /// Integer literals that overflow signed 64-bit are rejected at lex time,
 /// matching `nix-instantiate --parse` behaviour.
 #[test]


### PR DESCRIPTION

The formals loop kept going after a formal without a trailing comma,
so `{ a b }: 1` and `{ b ? 1 ... }: 1` were silently accepted.
Nix requires commas between formals and before ellipsis.

Found by fuzz_nix_compat.
