### PR TITLE
format: hoist trailing comments on chained binary operators

### DIFF
--- a/src/format/op.rs
+++ b/src/format/op.rs
@@ -110,7 +110,7 @@ pub(super) fn emit_operation_chain(
                 },
                 Some(op_leaf) => {
                     group_doc.line();
-                    op_leaf.emit(group_doc);
+                    op_leaf.move_trailing_comment_up().emit(group_doc);
                     group_doc.nested(|nested| {
                         absorb_operation(nested, expr);
                     });

--- a/src/regression_tests/format.rs
+++ b/src/regression_tests/format.rs
@@ -393,6 +393,17 @@ fn format_directive_in_priority_group_post_segment() {
     test_format!("z{\n/*nixfmt:disable*/\n}c");
 }
 
+/// `moveTrailingCommentUp` must be applied to chained binary operators
+/// (`+`, `++`, `//`) so that a trailing comment on the operator is rendered
+/// as a line comment *before* the operator line, matching Haskell nixfmt.
+/// Found via `diff_sweep` on nixpkgs (issue #88).
+#[test]
+fn format_operator_trailing_comment_hoisted() {
+    test_format!("\"a\" +  # comment\n\"b\"");
+    test_format!("x ++ # comment\ny");
+    test_format!("a // # comment\nb");
+}
+
 /// Hoisting the head's trail comment must not pull a `/* lang */` annotation
 /// off the string it labels, or pass 2 demotes it to `# c`. Found by
 /// `fuzz_idempotent`.

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_operator_trailing_comment_hoisted-2.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_operator_trailing_comment_hoisted-2.snap
@@ -1,0 +1,7 @@
+---
+source: src/regression_tests/format.rs
+description: "x ++ # comment\ny"
+---
+x
+# comment
+++ y

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_operator_trailing_comment_hoisted-3.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_operator_trailing_comment_hoisted-3.snap
@@ -1,0 +1,7 @@
+---
+source: src/regression_tests/format.rs
+description: "a // # comment\nb"
+---
+a
+# comment
+// b

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_operator_trailing_comment_hoisted.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_operator_trailing_comment_hoisted.snap
@@ -1,0 +1,7 @@
+---
+source: src/regression_tests/format.rs
+description: "\"a\" +  # comment\n\"b\""
+---
+"a"
+# comment
++ "b"


### PR DESCRIPTION

Trailing comments on +, ++, // operators were kept inline after the
operator, while nixfmt-haskell moves them to a line comment before
the operator line.

Apply move_trailing_comment_up() to operator leaves in the operation
chain renderer, matching the Haskell behavior.

Closes #88
