### PR TITLE
format: absorb simple set-parameter lambdas onto the colon line

### DIFF
--- a/src/ast/annotated.rs
+++ b/src/ast/annotated.rs
@@ -44,6 +44,7 @@ impl<T: Clone> Annotated<T> {
 pub struct TriviaSlot<'a> {
     pub pre_trivia: &'a Trivia,
     pub trail_comment: &'a Option<TrailingComment>,
+    pub span: Span,
 }
 
 /// Mutable counterpart of [`TriviaSlot`].
@@ -57,6 +58,7 @@ impl<'a, T> From<&'a Annotated<T>> for TriviaSlot<'a> {
         TriviaSlot {
             pre_trivia: &a.pre_trivia,
             trail_comment: &a.trail_comment,
+            span: a.span,
         }
     }
 }

--- a/src/format/absorb.rs
+++ b/src/format/absorb.rs
@@ -11,6 +11,14 @@ const fn is_lang_annot(p: &crate::ast::TriviaPiece) -> bool {
 use super::Width;
 use super::app::{AppCtx, emit_app};
 use super::op::emit_operation_chain;
+use super::params::can_flatten_attrs;
+
+impl Expression {
+    /// Haskell `sourceLine colon == firstTokenLine body`.
+    pub(super) fn body_on_colon_line(colon: &Annotated<Token>, body: &Self) -> bool {
+        colon.span.start_line() == body.first_token().span.start_line()
+    }
+}
 
 impl Term {
     /// Haskell `isAbsorbable` / `isAbsorbableTerm` (Pretty.hs).
@@ -63,6 +71,16 @@ impl Expression {
                 Self::Lambda { .. } => body.is_absorbable(),
                 _ => false,
             },
+            Self::Lambda {
+                param: Parameter::Set { open, attrs, close },
+                colon,
+                body,
+            } => {
+                can_flatten_attrs(open, attrs, close)
+                    && !open.has_trivia()
+                    && Self::body_on_colon_line(colon, body)
+                    && body.is_absorbable()
+            }
             _ => false,
         }
     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -25,6 +25,7 @@ mod term;
 
 use app::{AppCtx, emit_app, emit_app_parts};
 use op::emit_operation;
+use params::can_flatten_attrs;
 use stmt::{emit_if, emit_let, emit_with};
 use string::{emit_indented_string, emit_simple_string};
 use term::{emit_list, emit_paren, emit_set};
@@ -221,6 +222,19 @@ impl Emit for Expression {
             Self::Lambda { param, colon, body } => {
                 param.emit(doc);
                 colon.emit(doc);
+                if let Parameter::Set { open, attrs, close } = param {
+                    let same_line = Self::body_on_colon_line(colon, body);
+                    if same_line && can_flatten_attrs(open, attrs, close) && body.is_absorbable() {
+                        doc.hardspace();
+                        doc.priority_group(|g| body.emit(g));
+                        return;
+                    }
+                    if !same_line {
+                        doc.hardline();
+                        body.emit(doc);
+                        return;
+                    }
+                }
                 doc.line();
                 // Haskell `Abstraction` (set-param) clause: absorbable body
                 // gets `group (prettyTermWide t)`.

--- a/src/format/params.rs
+++ b/src/format/params.rs
@@ -168,17 +168,30 @@ fn move_params_comments(attrs: &[ParamAttr]) -> Vec<ParamAttr> {
     out
 }
 
-fn parameter_separator(open: &Leaf, attrs: &[ParamAttr], close: &Leaf) -> Elem {
-    if open.span.start_line() != close.span.start_line() {
-        return hardline();
+/// Haskell `canFlattenAttrs` (Pretty.hs): braces on one source line, no
+/// comments, and at most two plain attrs optionally followed by `...`.
+pub(super) fn can_flatten_attrs(open: &Leaf, attrs: &[ParamAttr], close: &Leaf) -> bool {
+    let attr_has_trivia = |a: &ParamAttr| match a {
+        ParamAttr::Attr { name, comma, .. } => {
+            name.has_trivia() || comma.as_ref().is_some_and(Annotated::has_trivia)
+        }
+        ParamAttr::Ellipsis(dots) => dots.has_trivia(),
+    };
+    if open.span.start_line() != close.span.start_line()
+        || close.has_trivia()
+        || attrs.iter().any(attr_has_trivia)
+    {
+        return false;
     }
-    // Allow a compact `{ a, b, ... }` only for at most two plain attrs
-    // optionally followed by `...`.
     let plain = match attrs.split_last() {
         Some((last, init)) if last.is_ellipsis() => init,
         _ => attrs,
     };
-    if plain.len() <= 2 && plain.iter().all(ParamAttr::has_no_default) {
+    plain.len() <= 2 && plain.iter().all(ParamAttr::has_no_default)
+}
+
+fn parameter_separator(open: &Leaf, attrs: &[ParamAttr], close: &Leaf) -> Elem {
+    if can_flatten_attrs(open, attrs, close) {
         line()
     } else {
         hardline()

--- a/src/regression_tests/format.rs
+++ b/src/regression_tests/format.rs
@@ -450,3 +450,17 @@ fn format_paren_with_comment_not_absorbed() {
     test_format!("{ o = (\n # c\n ''\n \"\n ''); }");
     test_format!("{ o = (/* lua */ ''print(1)\nx''); }");
 }
+
+/// Simple set-parameter lambdas absorb their body onto the colon line when
+/// the source had it there, and keep a line break otherwise (nixfmt-rs#131).
+/// Haskell: `Nixfmt.Pretty.canFlattenAttrs` and the `SetParameter` clauses of
+/// `isAbsorbableExpr` / `instance Pretty Expression`.
+#[test]
+fn format_set_param_lambda_absorbed() {
+    test_format!("{ machine = { pkgs, ... }: { x = 1; }; }");
+    test_format!("{ machine = { pkgs, ... }:\n  { x = 1; }; }");
+    test_format!("{ f = { a, b, c }: { x = 1; }; }");
+    test_format!("{ f = { a ? 1 }: { x = 1; }; }");
+    test_format!("f (\n  { file, test }:\n  \'\'sub \"${file}\" \"${test}\"\'\'\n) tests");
+    test_format!("{ ... }: {\n  name = \"lix\";\n}");
+}

--- a/src/regression_tests/ir.rs
+++ b/src/regression_tests/ir.rs
@@ -119,7 +119,7 @@ oracle_tests! {
         "(x: [ a ])",
     ],
 
-    /// Set-pattern abstraction with an absorbable body wraps the body in
-    /// `group (prettyTermWide t)`. Haskell: `Nixfmt.Pretty` `Abstraction` clause.
+    /// Flattenable set-pattern abstraction absorbs its body as
+    /// `hardspace <> group' Priority`. Haskell: `Nixfmt.Pretty` `Abstraction` clause.
     test_set_param_abstraction_absorbs_body => ["{ lib }: { a = 1; }"],
 }

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed-2.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed-2.snap
@@ -1,0 +1,11 @@
+---
+source: src/regression_tests/format.rs
+description: "{ machine = { pkgs, ... }:\n  { x = 1; }; }"
+---
+{
+  machine =
+    { pkgs, ... }:
+    {
+      x = 1;
+    };
+}

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed-3.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed-3.snap
@@ -1,0 +1,15 @@
+---
+source: src/regression_tests/format.rs
+description: "{ f = { a, b, c }: { x = 1; }; }"
+---
+{
+  f =
+    {
+      a,
+      b,
+      c,
+    }:
+    {
+      x = 1;
+    };
+}

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed-4.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed-4.snap
@@ -1,0 +1,13 @@
+---
+source: src/regression_tests/format.rs
+description: "{ f = { a ? 1 }: { x = 1; }; }"
+---
+{
+  f =
+    {
+      a ? 1,
+    }:
+    {
+      x = 1;
+    };
+}

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed-5.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed-5.snap
@@ -1,0 +1,8 @@
+---
+source: src/regression_tests/format.rs
+description: "f (\n  { file, test }:\n  ''sub \"${file}\" \"${test}\"''\n) tests"
+---
+f (
+  { file, test }:
+  ''sub "${file}" "${test}"''
+) tests

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed-6.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed-6.snap
@@ -1,0 +1,7 @@
+---
+source: src/regression_tests/format.rs
+description: "{ ... }: {\n  name = \"lix\";\n}"
+---
+{ ... }: {
+  name = "lix";
+}

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__format__format_set_param_lambda_absorbed.snap
@@ -1,0 +1,5 @@
+---
+source: src/regression_tests/format.rs
+description: "{ machine = { pkgs, ... }: { x = 1; }; }"
+---
+{ machine = { pkgs, ... }: { x = 1; }; }

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__ir__set_param_abstraction_absorbs_body.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__ir__set_param_abstraction_absorbs_body.snap
@@ -12,10 +12,10 @@ description: "{ lib }: { a = 1; }"
         [0;93;1m,[0m Text [0;92;1m0[0m [0;92;1m0[0m RegularT [0;97;1m"[0m[0;94;1m}[0m[0;97;1m"[0m
         [0;93;1m][0m
     [0;96;1m,[0m Text [0;92;1m0[0m [0;92;1m0[0m RegularT [0;97;1m"[0m[0;94;1m:[0m[0;97;1m"[0m
-    [0;96;1m,[0m Spacing Space
-    [0;96;1m,[0m Group RegularG
+    [0;96;1m,[0m Spacing Hardspace
+    [0;96;1m,[0m Group Priority
         [0;93;1m[[0m Text [0;92;1m0[0m [0;92;1m0[0m RegularT [0;97;1m"[0m[0;94;1m{[0m[0;97;1m"[0m
-        [0;93;1m,[0m Spacing Hardline
+        [0;93;1m,[0m Spacing Space
         [0;93;1m,[0m Group RegularG
             [0;35m[[0m Text [0;92;1m1[0m [0;92;1m0[0m RegularT [0;97;1m"[0m[0;94;1ma[0m[0;97;1m"[0m
             [0;35m,[0m Spacing Hardspace
@@ -26,7 +26,7 @@ description: "{ lib }: { a = 1; }"
                 [0;36m][0m
             [0;35m,[0m Text [0;92;1m1[0m [0;92;1m0[0m RegularT [0;97;1m"[0m[0;94;1m;[0m[0;97;1m"[0m
             [0;35m][0m
-        [0;93;1m,[0m Spacing Hardline
+        [0;93;1m,[0m Spacing Space
         [0;93;1m,[0m Text [0;92;1m0[0m [0;92;1m0[0m RegularT [0;97;1m"[0m[0;94;1m}[0m[0;97;1m"[0m
         [0;93;1m][0m
     [0;96;1m][0m

--- a/tests/fixtures/nixfmt/diff/idioms_pkgs_4/out-pure.nix
+++ b/tests/fixtures/nixfmt/diff/idioms_pkgs_4/out-pure.nix
@@ -149,49 +149,46 @@ in
 
 [
 
-  (
-    { }:
-    rec {
-      __raw = true;
+  ({ }: rec {
+    __raw = true;
 
-      stdenv = makeStdenv {
-        cc = null;
-        fetchurl = null;
-      };
-      stdenvNoCC = stdenv;
+    stdenv = makeStdenv {
+      cc = null;
+      fetchurl = null;
+    };
+    stdenvNoCC = stdenv;
 
-      cc =
-        let
-          nativePrefix =
-            {
-              # switch
-              i686-solaris = "/usr/gnu";
-              x86_64-solaris = "/opt/local/gcc47";
-            }
-            .${system} or "/usr";
-        in
-        import ../../build-support/cc-wrapper {
-          name = "cc-native";
+    cc =
+      let
+        nativePrefix =
+          {
+            # switch
+            i686-solaris = "/usr/gnu";
+            x86_64-solaris = "/opt/local/gcc47";
+          }
+          .${system} or "/usr";
+      in
+      import ../../build-support/cc-wrapper {
+        name = "cc-native";
+        nativeTools = true;
+        nativeLibc = true;
+        inherit lib nativePrefix;
+        bintools = import ../../build-support/bintools-wrapper {
+          name = "bintools";
+          inherit lib stdenvNoCC nativePrefix;
           nativeTools = true;
           nativeLibc = true;
-          inherit lib nativePrefix;
-          bintools = import ../../build-support/bintools-wrapper {
-            name = "bintools";
-            inherit lib stdenvNoCC nativePrefix;
-            nativeTools = true;
-            nativeLibc = true;
-          };
-          inherit stdenvNoCC;
         };
-
-      fetchurl = import ../../build-support/fetchurl {
-        inherit lib stdenvNoCC;
-        # Curl should be in /usr/bin or so.
-        curl = null;
+        inherit stdenvNoCC;
       };
 
-    }
-  )
+    fetchurl = import ../../build-support/fetchurl {
+      inherit lib stdenvNoCC;
+      # Curl should be in /usr/bin or so.
+      curl = null;
+    };
+
+  })
 
   # First build a stdenv based only on tools outside the store.
   (prevStage: {

--- a/tests/fixtures/nixfmt/diff/idioms_pkgs_4/out.nix
+++ b/tests/fixtures/nixfmt/diff/idioms_pkgs_4/out.nix
@@ -153,49 +153,46 @@ in
 
 [
 
-  (
-    { }:
-    rec {
-      __raw = true;
+  ({ }: rec {
+    __raw = true;
 
-      stdenv = makeStdenv {
-        cc = null;
-        fetchurl = null;
-      };
-      stdenvNoCC = stdenv;
+    stdenv = makeStdenv {
+      cc = null;
+      fetchurl = null;
+    };
+    stdenvNoCC = stdenv;
 
-      cc =
-        let
-          nativePrefix =
-            {
-              # switch
-              i686-solaris = "/usr/gnu";
-              x86_64-solaris = "/opt/local/gcc47";
-            }
-            .${system} or "/usr";
-        in
-        import ../../build-support/cc-wrapper {
-          name = "cc-native";
+    cc =
+      let
+        nativePrefix =
+          {
+            # switch
+            i686-solaris = "/usr/gnu";
+            x86_64-solaris = "/opt/local/gcc47";
+          }
+          .${system} or "/usr";
+      in
+      import ../../build-support/cc-wrapper {
+        name = "cc-native";
+        nativeTools = true;
+        nativeLibc = true;
+        inherit lib nativePrefix;
+        bintools = import ../../build-support/bintools-wrapper {
+          name = "bintools";
+          inherit lib stdenvNoCC nativePrefix;
           nativeTools = true;
           nativeLibc = true;
-          inherit lib nativePrefix;
-          bintools = import ../../build-support/bintools-wrapper {
-            name = "bintools";
-            inherit lib stdenvNoCC nativePrefix;
-            nativeTools = true;
-            nativeLibc = true;
-          };
-          inherit stdenvNoCC;
         };
-
-      fetchurl = import ../../build-support/fetchurl {
-        inherit lib stdenvNoCC;
-        # Curl should be in /usr/bin or so.
-        curl = null;
+        inherit stdenvNoCC;
       };
 
-    }
-  )
+    fetchurl = import ../../build-support/fetchurl {
+      inherit lib stdenvNoCC;
+      # Curl should be in /usr/bin or so.
+      curl = null;
+    };
+
+  })
 
   # First build a stdenv based only on tools outside the store.
   (prevStage: {

--- a/tests/fixtures/nixfmt/diff/lambda/in.nix
+++ b/tests/fixtures/nixfmt/diff/lambda/in.nix
@@ -113,4 +113,58 @@ in
     e = { a, b, }: { foo = true; };
     e = { a, b, }: [ 1 ];
   }
+
+  ({ bar }: { baz = "foobar"; })
+  ({ bar }: [ 1 2 3 ])
+  ({ x,y,z }: { x=y+z; })
+
+  ({ x }: { y }: { z=x+y; })
+  ({ x }: 
+  { y }: { z=x+y; })
+
+  ({ x,y }: { z = x+y; })
+  ({ x,y }: 
+  { z = x+y; })
+
+  # multiline attr parameters
+  ({a,
+  b}: {
+    a = 1;
+    b = 2;
+  })
+  # multiline attr parameters with line break
+  ({a,
+
+  b}: {
+    a = 1;
+    b = 2;
+  })
+  # empty multiline attr
+  ({
+  }: {
+    a = 1;
+    b = 2;
+  })
+  # empty multiline attr with line break
+  ({
+
+  }: {
+    a = 1;
+    b = 2;
+  })
+
+  # comment on attr parameter
+  ({ # comment
+    a }: { x = 1; })
+  # inline comment on attr parameter
+  ({ /* inline */ a }: { x = 1; })
+  # comment after attr parameter
+  ({ a /* inline */ }: { x = 1; })
+  # attr parameter with default value
+  ({ a ? 1 }: { x = 1; })
+  # attr parameter with language annotation default
+  ({ script ? /* bash */ "echo foo" }: { x = 1; })
+  # simple attr with context parameter
+  (a@{ b }: { x = 1; })
+  ({ b }@a: { x = 1; })
 ]

--- a/tests/fixtures/nixfmt/diff/lambda/out-pure.nix
+++ b/tests/fixtures/nixfmt/diff/lambda/out-pure.nix
@@ -74,12 +74,9 @@ in
     a
   )
 
-  (
-    { pkgs, ... }:
-    {
-      # Stuff
-    }
-  )
+  ({ pkgs, ... }: {
+    # Stuff
+  })
 
   (
     { pkgs, ... }:
@@ -88,21 +85,13 @@ in
     pkgs
   )
 
-  (
-    a:
-    { b, ... }:
-    c: {
-      # Stuff
-    }
-  )
+  (a: { b, ... }: c: {
+    # Stuff
+  })
 
-  (
-    a:
-    { b, c, ... }:
-    d: {
-      # Stuff
-    }
-  )
+  (a: { b, c, ... }: d: {
+    # Stuff
+  })
 
   (
     {
@@ -200,23 +189,118 @@ in
         biocVersion,
       }:
       [ "mirror://bioc/${biocVersion}/data/experiment/${name}_${version}.tar.gz" ];
-    c =
-      { ... }:
-      {
-        foo = true;
-      };
+    c = { ... }: { foo = true; };
     c = { ... }: [ 1 ];
-    d =
-      { a }:
-      {
-        foo = true;
-      };
+    d = { a }: { foo = true; };
     d = { a }: [ 1 ];
-    e =
-      { a, b }:
-      {
-        foo = true;
-      };
+    e = { a, b }: { foo = true; };
     e = { a, b }: [ 1 ];
   }
+
+  ({ bar }: { baz = "foobar"; })
+  ({ bar }: [
+    1
+    2
+    3
+  ])
+  (
+    {
+      x,
+      y,
+      z,
+    }:
+    {
+      x = y + z;
+    }
+  )
+
+  ({ x }: { y }: { z = x + y; })
+  ({ x }: { y }: { z = x + y; })
+
+  ({ x, y }: { z = x + y; })
+  ({ x, y }: { z = x + y; })
+
+  # multiline attr parameters
+  ({ a, b }: {
+    a = 1;
+    b = 2;
+  })
+  # multiline attr parameters with line break
+  (
+    {
+      a,
+
+      b,
+    }:
+    {
+      a = 1;
+      b = 2;
+    }
+  )
+  # empty multiline attr
+  ({ }: {
+    a = 1;
+    b = 2;
+  })
+  # empty multiline attr with line break
+  (
+    {
+
+    }:
+    {
+      a = 1;
+      b = 2;
+    }
+  )
+
+  # comment on attr parameter
+  (
+    # comment
+    { a }: { x = 1; }
+  )
+  # inline comment on attr parameter
+  (
+    # inline
+    { a }: { x = 1; }
+  )
+  # comment after attr parameter
+  (
+    {
+      a, # inline
+    }:
+    {
+      x = 1;
+    }
+  )
+  # attr parameter with default value
+  (
+    {
+      a ? 1,
+    }:
+    {
+      x = 1;
+    }
+  )
+  # attr parameter with language annotation default
+  (
+    {
+      script ? /* bash */ "echo foo",
+    }:
+    {
+      x = 1;
+    }
+  )
+  # simple attr with context parameter
+  (
+    a@{ b }:
+    {
+      x = 1;
+    }
+  )
+  (
+    { b }@a:
+    {
+      x = 1;
+    }
+  )
 ]

--- a/tests/fixtures/nixfmt/diff/lambda/out.nix
+++ b/tests/fixtures/nixfmt/diff/lambda/out.nix
@@ -78,12 +78,9 @@ in
     a
   )
 
-  (
-    { pkgs, ... }:
-    {
-      # Stuff
-    }
-  )
+  ({ pkgs, ... }: {
+    # Stuff
+  })
 
   (
     { pkgs, ... }:
@@ -211,23 +208,141 @@ in
         biocVersion,
       }:
       [ "mirror://bioc/${biocVersion}/data/experiment/${name}_${version}.tar.gz" ];
-    c =
-      { ... }:
-      {
-        foo = true;
-      };
+    c = { ... }: { foo = true; };
     c = { ... }: [ 1 ];
-    d =
-      { a }:
-      {
-        foo = true;
-      };
+    d = { a }: { foo = true; };
     d = { a }: [ 1 ];
-    e =
-      { a, b }:
-      {
-        foo = true;
-      };
+    e = { a, b }: { foo = true; };
     e = { a, b }: [ 1 ];
   }
+
+  ({ bar }: { baz = "foobar"; })
+  ({ bar }: [
+    1
+    2
+    3
+  ])
+  (
+    {
+      x,
+      y,
+      z,
+    }:
+    {
+      x = y + z;
+    }
+  )
+
+  ({ x }: { y }: { z = x + y; })
+  (
+    { x }:
+    { y }: { z = x + y; }
+  )
+
+  ({ x, y }: { z = x + y; })
+  (
+    { x, y }:
+    {
+      z = x + y;
+    }
+  )
+
+  # multiline attr parameters
+  (
+    {
+      a,
+      b,
+    }:
+    {
+      a = 1;
+      b = 2;
+    }
+  )
+  # multiline attr parameters with line break
+  (
+    {
+      a,
+
+      b,
+    }:
+    {
+      a = 1;
+      b = 2;
+    }
+  )
+  # empty multiline attr
+  (
+    {
+    }:
+    {
+      a = 1;
+      b = 2;
+    }
+  )
+  # empty multiline attr with line break
+  (
+    {
+
+    }:
+    {
+      a = 1;
+      b = 2;
+    }
+  )
+
+  # comment on attr parameter
+  (
+    # comment
+    {
+      a,
+    }:
+    {
+      x = 1;
+    }
+  )
+  # inline comment on attr parameter
+  (
+    # inline
+    { a }: { x = 1; }
+  )
+  # comment after attr parameter
+  (
+    {
+      a, # inline
+    }:
+    {
+      x = 1;
+    }
+  )
+  # attr parameter with default value
+  (
+    {
+      a ? 1,
+    }:
+    {
+      x = 1;
+    }
+  )
+  # attr parameter with language annotation default
+  (
+    {
+      script ? /* bash */ "echo foo",
+    }:
+    {
+      x = 1;
+    }
+  )
+  # simple attr with context parameter
+  (
+    a@{ b }:
+    {
+      x = 1;
+    }
+  )
+  (
+    { b }@a:
+    {
+      x = 1;
+    }
+  )
 ]


### PR DESCRIPTION

nixfmt keeps `x = { pkgs, ... }: {` on one line when the source wrote it
that way, and keeps a line break after the colon if the source had one.
Port upstream 5e37fc9 so nixpkgs' nixos/tests format identically, and
re-vendor the lambda and idioms_pkgs_4 fixtures.

Closes: https://github.com/Mic92/nixfmt-rs/issues/131
