### PR TITLE
parser: bound expression nesting depth

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -59,7 +59,7 @@ pub struct LexerState {
     recent_hspace: usize,
     /// `directive_offsets` length at save time, truncated on restore.
     directive_offsets_len: usize,
-    interp_depth: u32,
+    interp_id: u32,
 }
 
 pub struct Lexer {
@@ -83,11 +83,13 @@ pub struct Lexer {
     /// does not allocate on every call.
     trivia_scratch: Vec<RawTrivia>,
     /// `/*nixfmt:*/` directives seen so far: `(line_start, line_end,
-    /// is_disable, interp_depth)`. Paired up in [`Self::take_directive_regions`].
+    /// is_disable, interp_id)`. Paired up in [`Self::take_directive_regions`].
     directive_offsets: Vec<(usize, usize, bool, u32)>,
-    /// `${}` nesting depth, maintained by the parser via
-    /// [`Self::enter_interp`] / [`Self::exit_interp`].
-    interp_depth: u32,
+    /// Unique id of the enclosing `${}`, 0 at top level. Maintained by the
+    /// parser via [`Self::enter_interp`] / [`Self::exit_interp`].
+    interp_id: u32,
+    /// Last id handed out by `enter_interp`. Never rewound so ids stay unique.
+    interp_counter: u32,
 }
 
 impl Lexer {
@@ -103,23 +105,26 @@ impl Lexer {
             trivia_start: None,
             trivia_scratch: Vec::new(),
             directive_offsets: Vec::new(),
-            interp_depth: 0,
+            interp_id: 0,
+            interp_counter: 0,
         }
     }
 
-    pub(crate) const fn enter_interp(&mut self) {
-        self.interp_depth += 1;
+    /// Returns the outer id to hand back to [`Self::exit_interp`].
+    pub(crate) const fn enter_interp(&mut self) -> u32 {
+        self.interp_counter += 1;
+        std::mem::replace(&mut self.interp_id, self.interp_counter)
     }
 
-    pub(crate) const fn exit_interp(&mut self) {
-        self.interp_depth = self.interp_depth.saturating_sub(1);
+    pub(crate) const fn exit_interp(&mut self, outer: u32) {
+        self.interp_id = outer;
     }
 
     /// Pair recorded directives in document order. A `disable` opens a region
-    /// only with a matching `enable` at the same `${}` depth, or EOF at depth
-    /// 0; otherwise it is demoted to `Inert` because the verbatim splice would
-    /// partially overlap a `''…''` body and make its indent stripping diverge
-    /// across passes. The renderer replays the same pairing over the markers
+    /// only with a matching `enable` in the same `${}` (or both at top level),
+    /// or EOF at top level. Otherwise it is demoted to `Inert` because the
+    /// verbatim splice would partially overlap a `''…''` body and make its
+    /// indent stripping diverge across passes. The renderer replays the same pairing over the markers
     /// it sees, so the action list and the document stay aligned.
     pub(crate) fn take_directive_regions(&mut self) -> Vec<DirectiveAction> {
         let mut offsets = std::mem::take(&mut self.directive_offsets);
@@ -132,18 +137,18 @@ impl Lexer {
         offsets.dedup_by_key(|&mut (start, ..)| start);
 
         let mut actions = vec![DirectiveAction::Inert; offsets.len()];
-        // (action index, line start, interp depth) of the currently open disable.
+        // (action index, line start, interp id) of the currently open disable.
         let mut open: Option<(usize, usize, u32)> = None;
-        for (n, &(line_start, line_end, is_disable, depth)) in offsets.iter().enumerate() {
+        for (n, &(line_start, line_end, is_disable, id)) in offsets.iter().enumerate() {
             match (is_disable, open) {
-                (true, None) => open = Some((n, line_start, depth)),
-                // Matching enable at the same `${}` nesting depth closes the region.
-                (false, Some((begin_n, start, open_depth))) if depth == open_depth => {
+                (true, None) => open = Some((n, line_start, id)),
+                // Matching enable in the same `${}` closes the region.
+                (false, Some((begin_n, start, open_id))) if id == open_id => {
                     actions[begin_n] = DirectiveAction::Begin(self.source[start..line_end].into());
                     actions[n] = DirectiveAction::End;
                     open = None;
                 }
-                // Nested disable / lone enable / depth-mismatched enable: inert.
+                // Nested disable, lone enable, or enable in another `${}`: inert.
                 _ => {}
             }
         }
@@ -168,7 +173,7 @@ impl Lexer {
             recent_newlines: self.recent_newlines,
             recent_hspace: self.recent_hspace,
             directive_offsets_len: self.directive_offsets.len(),
-            interp_depth: self.interp_depth,
+            interp_id: self.interp_id,
         }
     }
 
@@ -181,7 +186,7 @@ impl Lexer {
         self.recent_newlines = state.recent_newlines;
         self.recent_hspace = state.recent_hspace;
         self.directive_offsets.truncate(state.directive_offsets_len);
-        self.interp_depth = state.interp_depth;
+        self.interp_id = state.interp_id;
     }
 
     /// Parse a lexeme (token with trivia annotations)
@@ -214,7 +219,7 @@ impl Lexer {
         // Defer trivia when returning to string content so `/*` is not
         // misinterpreted as a block comment.
         let skip_trivia = matches!(token, Token::DoubleQuote | Token::DoubleSingleQuote)
-            || (matches!(token, Token::BraceClose) && self.interp_depth > 0);
+            || (matches!(token, Token::BraceClose) && self.interp_id > 0);
 
         let trailing_comment;
         if skip_trivia {
@@ -370,7 +375,7 @@ impl Lexer {
                             line_start,
                             line_end,
                             is_disable,
-                            self.interp_depth,
+                            self.interp_id,
                         ));
                         self.trivia_scratch.push(directive);
                     } else if let Some(lang_annot) = self.try_parse_language_annotation() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,6 +225,12 @@ fn process(o: &Opts, name: &str, source: &str, in_place: bool) -> bool {
 }
 
 fn main() {
+    // Walker threads need as much stack as the main thread so the parser's
+    // nesting limit is reached before the stack is.
+    if std::env::var_os("RUST_MIN_STACK").is_none() {
+        // SAFETY: no other threads exist yet.
+        unsafe { std::env::set_var("RUST_MIN_STACK", (8usize << 20).to_string()) };
+    }
     let o = match parse_args() {
         Ok(o) => o,
         Err(e) => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -23,7 +23,11 @@ pub struct Parser {
     lexer: Lexer,
     /// Current token
     current: Annotated<Token>,
+    /// Open recursive constructs. Bounded so hostile input cannot overflow the stack.
+    depth: u32,
 }
+
+const MAX_DEPTH: u32 = 512;
 
 /// Outcome of `finish_abstraction`: either a full lambda was parsed, or no
 /// `:`/`@` followed and the tentative parameter is handed back so the caller
@@ -48,7 +52,26 @@ impl Parser {
         let mut lexer = Lexer::new(source);
         lexer.start_parse()?;
         let current = lexer.lexeme()?;
-        Ok(Self { lexer, current })
+        Ok(Self {
+            lexer,
+            current,
+            depth: 0,
+        })
+    }
+
+    /// Run `f` one nesting level deeper, failing once `MAX_DEPTH` is exceeded.
+    pub(super) fn nested<T>(&mut self, f: impl FnOnce(&mut Self) -> Result<T>) -> Result<T> {
+        if self.depth >= MAX_DEPTH {
+            return Err(ParseError::invalid(
+                self.current.span,
+                format!("expression nested more than {MAX_DEPTH} levels deep"),
+                None,
+            ));
+        }
+        self.depth += 1;
+        let r = f(self);
+        self.depth -= 1;
+        r
     }
 
     /// See [`Lexer::take_directive_regions`].
@@ -72,6 +95,10 @@ impl Parser {
 
     /// Parse an expression (top-level)
     fn parse_expression(&mut self) -> Result<Expression> {
+        self.nested(Self::parse_expression_inner)
+    }
+
+    fn parse_expression_inner(&mut self) -> Result<Expression> {
         // Match Haskell's order: try operation, then abstraction, then keywords
         match &self.current.value {
             Token::Let => {

--- a/src/parser/strings.rs
+++ b/src/parser/strings.rs
@@ -123,11 +123,11 @@ impl Parser {
 
     /// Parse string interpolation: ${expr}
     pub(super) fn parse_string_interpolation(&mut self) -> Result<StringPart> {
-        // Bracket the body with enter/exit so directive recognition knows its
-        // `${}` depth. On `Err` the parse is abandoned anyway.
-        self.lexer.enter_interp();
+        // Bracket the body so directive recognition knows which `${}` it
+        // is in. On `Err` the parse is abandoned anyway.
+        let outer = self.lexer.enter_interp();
         let result = self.parse_string_interpolation_inner();
-        self.lexer.exit_interp();
+        self.lexer.exit_interp(outer);
         result
     }
 

--- a/src/parser/term.rs
+++ b/src/parser/term.rs
@@ -12,7 +12,7 @@ impl Parser {
         match &self.current.value {
             Token::Minus => {
                 let op = self.take_and_advance()?;
-                let inner = self.parse_application()?;
+                let inner = self.nested(Self::parse_application)?;
                 return Ok(Expression::Negation {
                     minus: op,
                     expr: Box::new(inner),
@@ -20,7 +20,7 @@ impl Parser {
             }
             Token::Not => {
                 let op = self.take_and_advance()?;
-                let inner = self.parse_application()?;
+                let inner = self.nested(Self::parse_application)?;
                 return Ok(Expression::Not {
                     bang: op,
                     expr: Box::new(inner),
@@ -91,6 +91,10 @@ impl Parser {
 
     /// Parse a term (atom), including postfix selection
     pub(super) fn parse_term(&mut self) -> Result<Term> {
+        self.nested(Self::parse_term_inner)
+    }
+
+    fn parse_term_inner(&mut self) -> Result<Term> {
         if self.looks_like_uri() {
             return self.parse_uri();
         }

--- a/src/regression_tests/fuzz.rs
+++ b/src/regression_tests/fuzz.rs
@@ -209,3 +209,13 @@ fn fuzz_deep_nesting_is_an_error_not_a_crash() {
         .join()
         .unwrap();
 }
+
+/// A disable in one `${}` and an enable in a sibling `${}` sit at the same
+/// depth but must not pair, or the region would splice the indented string
+/// body between them.
+#[test]
+fn fuzz_directive_pair_across_sibling_interpolations() {
+    roundtrip("{t=''${\n/*nixfmt:disable*/\n3}\n${\n/*nixfmt:enable*/\n1}'';}");
+    // Same interpolation still pairs.
+    roundtrip("{t=''${\n/*nixfmt:disable*/\n3\n/*nixfmt:enable*/\n}'';  u   =   1;}");
+}

--- a/src/regression_tests/fuzz.rs
+++ b/src/regression_tests/fuzz.rs
@@ -185,3 +185,27 @@ fn fuzz_let_in_trail_comment_app_width() {
     roundtrip(&format!("with p;#c\n f {long} g"));
     roundtrip(&format!("let in\n#c\nf {long} g"));
 }
+
+/// Deeply nested input must yield a parse error instead of overflowing the
+/// stack. Debug builds need far more stack per level than release, hence 32 MiB.
+#[test]
+fn fuzz_deep_nesting_is_an_error_not_a_crash() {
+    std::thread::Builder::new()
+        .stack_size(32 << 20)
+        .spawn(|| {
+            let n = 100_000;
+            for src in [
+                format!("{}1", "-".repeat(n)),
+                format!("{}a", "!".repeat(n)),
+                format!("{}1{}", "(".repeat(n), ")".repeat(n)),
+                format!("{}1{}", "[".repeat(n), "]".repeat(n)),
+                format!("{}1;{}", "{a=".repeat(n), "}".repeat(n)),
+                format!("{}a", "a: ".repeat(n)),
+            ] {
+                assert!(crate::parse(&src).is_err(), "{}", &src[..20]);
+            }
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+}


### PR DESCRIPTION

The fuzzer found that a long run of prefix operators or brackets makes
the recursive descent parser overflow its stack and abort. nixpkgs
peaks at 251 levels, so reject anything beyond 512 with a parse error.

A release build needs roughly 4 KiB of stack per lambda level, which
does not fit the 2 MiB default of the ignore walker threads. Raise
RUST_MIN_STACK to 8 MiB so they match the main thread.
