### PR TITLE
tests: tolerate EPIPE when the child exits before reading stdin

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -22,17 +22,12 @@ fn run(program: &str, args: &[&str], stdin: Option<&str>) -> Output {
         .spawn()
         .unwrap_or_else(|e| panic!("spawn {program}: {e}"));
     if let Some(s) = stdin {
-        // A child that rejects its arguments exits before reading stdin, so this write
-        // races with the child's exit and fails with EPIPE. That is not a test failure:
-        // the assertions that matter are on the exit code and stderr.
-        let mut sin = child.stdin.take().unwrap();
-        if let Err(e) = sin.write_all(s.as_bytes()) {
+        // EPIPE is expected when the child rejects its args and exits without reading.
+        if let Err(e) = child.stdin.take().unwrap().write_all(s.as_bytes()) {
             assert_eq!(e.kind(), std::io::ErrorKind::BrokenPipe, "write stdin: {e}");
         }
-        drop(sin);
-    } else {
-        drop(child.stdin.take());
     }
+    drop(child.stdin.take());
     child.wait_with_output().unwrap()
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -22,7 +22,14 @@ fn run(program: &str, args: &[&str], stdin: Option<&str>) -> Output {
         .spawn()
         .unwrap_or_else(|e| panic!("spawn {program}: {e}"));
     if let Some(s) = stdin {
-        child.stdin.take().unwrap().write_all(s.as_bytes()).unwrap();
+        // A child that rejects its arguments exits before reading stdin, so this write
+        // races with the child's exit and fails with EPIPE. That is not a test failure:
+        // the assertions that matter are on the exit code and stderr.
+        let mut sin = child.stdin.take().unwrap();
+        if let Err(e) = sin.write_all(s.as_bytes()) {
+            assert_eq!(e.kind(), std::io::ErrorKind::BrokenPipe, "write stdin: {e}");
+        }
+        drop(sin);
     } else {
         drop(child.stdin.take());
     }


### PR DESCRIPTION
Fixes the flaky test that caused the 0.5.2 release to ship with zero assets (#142).

## What happens

`message_format_rejects_unknown_value` passes `--message-format=xml`, which is rejected during
argument validation, so `nixfmt` exits without ever reading stdin. The `run()` helper then writes
the payload into a pipe whose read end may already be closed:

```rust
child.stdin.take().unwrap().write_all(s.as_bytes()).unwrap();   // tests/cli.rs:25
```

Whether the write lands before the child exits is pure scheduling, so the `.unwrap()` panics
intermittently:

```
thread 'message_format_rejects_unknown_value' panicked at tests/cli.rs:25:61:
called `Result::unwrap()` on an `Err` value: Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }
```

## Why the release had no assets

In [the 0.5.2 release run](https://github.com/Mic92/nixfmt-rs/actions/runs/33248614727) both Linux
static jobs failed on exactly this one test — 25 passed, 1 failed — while the macOS and wasm jobs
succeeded and `buildbot/nix-build` on the same commit was green. `publish` is gated on
`needs: build`, so it was skipped and nothing was uploaded.

## Reproduction

The race does not reproduce on its own — 300 consecutive runs of the test on darwin/arm64 all
passed. Inserting a 200 ms sleep immediately before `write_all` to widen the window reproduces the
CI panic verbatim:

```
thread 'message_format_rejects_unknown_value' panicked at tests/cli.rs:26:61:
called `Result::unwrap()` on an `Err` value: Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }
```

With this patch applied the test passes even with that sleep still in place.

## Verification

Sleep removed, full suite on darwin/arm64:

```
test result: ok. 292 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```

`cargo fmt --check` and `cargo clippy --release --all-targets` are both clean.

I have not reproduced the failure on linux/musl, which is where CI hit it — only the mechanism,
by widening the race on macOS.

## Notes

Only `BrokenPipe` is accepted; every other I/O error still fails. The assertions that matter — the
exit code and the stderr contents — are untouched, so a real regression is still caught.

A smaller alternative would be to change this one test to pass `None` instead of
`Some(UNFORMATTED)`, but fixing the helper means any future test that feeds stdin to an
argument-rejecting invocation cannot hit the same race.

Once this lands, `release-assets.yml` can be re-run via `workflow_dispatch` with `tag: 0.5.2` to
attach the missing assets to the existing tag — no new release needed.

---

Written with the help of Claude Code; the diagnosis and the measurements above were reviewed and
reproduced by me.
