### PR TITLE
parser: a has-attr test may follow a function application

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -317,8 +317,6 @@ impl Parser {
     fn parse_operation_or_lambda(&mut self) -> Result<Expression> {
         let expr = self.parse_application()?;
 
-        // Member check (?) is handled in parse_application so that `?` binds tighter than prefix `!`/`-`.
-
         if matches!(self.current.value, Token::Colon | Token::At) {
             return Err(Self::reject_non_parameter_expr(&expr));
         }

--- a/src/parser/operators.rs
+++ b/src/parser/operators.rs
@@ -66,26 +66,7 @@ impl Parser {
 
     /// Continue parsing operation from a given left expression
     pub(super) fn continue_operation_from(&mut self, expr: Expression) -> Result<Expression> {
-        let mut expr = expr;
-
-        while self.is_term_start() && !self.is_expression_end() {
-            let arg = Expression::Term(self.parse_term()?);
-            expr = Expression::Apply {
-                func: Box::new(expr),
-                arg: Box::new(arg),
-            };
-        }
-
-        // `?` binds to the whole application, not the head term: `f x ? a`
-        // is `(f x) ? a`. parse_application (term.rs) orders it the same
-        // way; hoisting this test above the loop breaks the pair.
-        if matches!(self.current.value, Token::Question) {
-            expr = Expression::HasAttr {
-                lhs: Box::new(expr),
-                checks: self.parse_presence_checks()?,
-            };
-        }
-
+        let expr = self.parse_application_tail(expr)?;
         self.maybe_parse_binary_operation(expr)
     }
 

--- a/src/parser/operators.rs
+++ b/src/parser/operators.rs
@@ -66,24 +66,25 @@ impl Parser {
 
     /// Continue parsing operation from a given left expression
     pub(super) fn continue_operation_from(&mut self, expr: Expression) -> Result<Expression> {
-        let expr = if matches!(self.current.value, Token::Question) {
-            Expression::HasAttr {
+        let mut expr = expr;
+
+        while self.is_term_start() && !self.is_expression_end() {
+            let arg = Expression::Term(self.parse_term()?);
+            expr = Expression::Apply {
+                func: Box::new(expr),
+                arg: Box::new(arg),
+            };
+        }
+
+        // `?` binds to the whole application, not the head term: `f x ? a`
+        // is `(f x) ? a`. parse_application (term.rs) orders it the same
+        // way; hoisting this test above the loop breaks the pair.
+        if matches!(self.current.value, Token::Question) {
+            expr = Expression::HasAttr {
                 lhs: Box::new(expr),
                 checks: self.parse_presence_checks()?,
-            }
-        } else if self.is_term_start() {
-            let mut app_expr = expr;
-            while self.is_term_start() && !self.is_expression_end() {
-                let arg = Expression::Term(self.parse_term()?);
-                app_expr = Expression::Apply {
-                    func: Box::new(app_expr),
-                    arg: Box::new(arg),
-                };
-            }
-            app_expr
-        } else {
-            expr
-        };
+            };
+        }
 
         self.maybe_parse_binary_operation(expr)
     }

--- a/src/parser/term.rs
+++ b/src/parser/term.rs
@@ -29,10 +29,15 @@ impl Parser {
             _ => {}
         }
 
-        let mut expr = Expression::Term(self.parse_term()?);
+        let head = Expression::Term(self.parse_term()?);
+        self.parse_application_tail(head)
+    }
 
-        // Keep applying while we see more TERMS (not unary ops)
-        // IMPORTANT: Don't treat binary operators as term starts even if they could start paths
+    /// Apply following argument terms to `head`, then any postfix `?` checks.
+    /// Postfix `?` binds tighter than prefix `!`/`-` but looser than
+    /// application: `!f x ? a` is `!((f x) ? a)`.
+    pub(super) fn parse_application_tail(&mut self, head: Expression) -> Result<Expression> {
+        let mut expr = head;
         while self.is_term_start() && !self.is_binary_op() && !self.is_expression_end() {
             let arg = Expression::Term(self.parse_term()?);
             expr = Expression::Apply {
@@ -40,16 +45,12 @@ impl Parser {
                 arg: Box::new(arg),
             };
         }
-
-        // Postfix `?` has higher precedence than prefix `!`/`-`; checking it here ensures
-        // `!a ? b` parses as `!(a ? b)`, not `(!a) ? b`.
         if matches!(self.current.value, Token::Question) {
             expr = Expression::HasAttr {
                 lhs: Box::new(expr),
                 checks: self.parse_presence_checks()?,
             };
         }
-
         Ok(expr)
     }
 

--- a/src/regression_tests/parser.rs
+++ b/src/regression_tests/parser.rs
@@ -14,6 +14,17 @@ oracle_tests! {
 
     regression_or_as_identifier => ["or"],
 
+    // A `?` check binds to the whole application: `f x ? a` is `(f x) ? a`,
+    // which nix accepts. The operator path tested for `?` before consuming
+    // the argument terms, so only a parenthesised lhs survived.
+    regression_has_attr_after_application => [
+        "f x ? a",
+        "f x y ? a.b",
+        "lib.functionArgs (import ./x) ? muster",
+        "f x ? a ? b",
+        "(f x) ? a",
+    ],
+
     // nixfmt a061bd5: a `/* lang */` block comment is only a language
     // annotation when at most one newline separates it from the string.
     // LanguageAnnotation must be wrapped in brackets in --ast output.

--- a/src/regression_tests/parser.rs
+++ b/src/regression_tests/parser.rs
@@ -14,9 +14,7 @@ oracle_tests! {
 
     regression_or_as_identifier => ["or"],
 
-    // A `?` check binds to the whole application: `f x ? a` is `(f x) ? a`,
-    // which nix accepts. The operator path tested for `?` before consuming
-    // the argument terms, so only a parenthesised lhs survived.
+    // `f x ? a` is `(f x) ? a`; the ident-head path used to drop the `?`.
     regression_has_attr_after_application => [
         "f x ? a",
         "f x y ? a.b",

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__parser__regression_has_attr_after_application-2.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__parser__regression_has_attr_after_application-2.snap
@@ -1,0 +1,82 @@
+---
+source: src/regression_tests/parser.rs
+description: f x y ? a.b
+---
+MemberCheck
+    [0;95;1m([0m Application
+        [0;96;1m([0m Application
+            [0;93;1m([0m Term
+                [0;35m([0m Token
+                    [0;36m([0m Ann
+                        [0;33m{[0m preTrivia = fromList [0;35;1m[[0m[0;35;1m][0m
+                        [0;33m,[0m sourceLine = Pos [0;92;1m1[0m
+                        [0;33m,[0m value = Identifier [0;97;1m"[0m[0;94;1mf[0m[0;97;1m"[0m
+                        [0;33m,[0m trailComment = Nothing
+                        [0;33m}[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+            [0;93;1m)[0m
+            [0;93;1m([0m Term
+                [0;35m([0m Token
+                    [0;36m([0m Ann
+                        [0;33m{[0m preTrivia = fromList [0;35;1m[[0m[0;35;1m][0m
+                        [0;33m,[0m sourceLine = Pos [0;92;1m1[0m
+                        [0;33m,[0m value = Identifier [0;97;1m"[0m[0;94;1mx[0m[0;97;1m"[0m
+                        [0;33m,[0m trailComment = Nothing
+                        [0;33m}[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+            [0;93;1m)[0m
+        [0;96;1m)[0m
+        [0;96;1m([0m Term
+            [0;93;1m([0m Token
+                [0;35m([0m Ann
+                    [0;36m{[0m preTrivia = fromList [0;33m[[0m[0;33m][0m
+                    [0;36m,[0m sourceLine = Pos [0;92;1m1[0m
+                    [0;36m,[0m value = Identifier [0;97;1m"[0m[0;94;1my[0m[0;97;1m"[0m
+                    [0;36m,[0m trailComment = Nothing
+                    [0;36m}[0m
+                [0;35m)[0m
+            [0;93;1m)[0m
+        [0;96;1m)[0m
+    [0;95;1m)[0m
+    [0;95;1m([0m
+        [0;96;1m([0m Ann
+            [0;93;1m{[0m preTrivia = fromList [0;35m[[0m[0;35m][0m
+            [0;93;1m,[0m sourceLine = Pos [0;92;1m1[0m
+            [0;93;1m,[0m value = TQuestion
+            [0;93;1m,[0m trailComment = Nothing
+            [0;93;1m}[0m
+        [0;96;1m,[0m
+            [0;93;1m[[0m Selector Nothing
+                [0;35m([0m IDSelector
+                    [0;36m([0m Ann
+                        [0;33m{[0m preTrivia = fromList [0;35;1m[[0m[0;35;1m][0m
+                        [0;33m,[0m sourceLine = Pos [0;92;1m1[0m
+                        [0;33m,[0m value = Identifier [0;97;1m"[0m[0;94;1ma[0m[0;97;1m"[0m
+                        [0;33m,[0m trailComment = Nothing
+                        [0;33m}[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+            [0;93;1m,[0m Selector
+                [0;35m([0m Just
+                    [0;36m([0m Ann
+                        [0;33m{[0m preTrivia = fromList [0;35;1m[[0m[0;35;1m][0m
+                        [0;33m,[0m sourceLine = Pos [0;92;1m1[0m
+                        [0;33m,[0m value = TDot
+                        [0;33m,[0m trailComment = Nothing
+                        [0;33m}[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+                [0;35m([0m IDSelector
+                    [0;36m([0m Ann
+                        [0;33m{[0m preTrivia = fromList [0;35;1m[[0m[0;35;1m][0m
+                        [0;33m,[0m sourceLine = Pos [0;92;1m1[0m
+                        [0;33m,[0m value = Identifier [0;97;1m"[0m[0;94;1mb[0m[0;97;1m"[0m
+                        [0;33m,[0m trailComment = Nothing
+                        [0;33m}[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+            [0;93;1m][0m
+        [0;96;1m)[0m :| [0;96;1m[[0m[0;96;1m][0m
+    [0;95;1m)[0m

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__parser__regression_has_attr_after_application-3.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__parser__regression_has_attr_after_application-3.snap
@@ -1,0 +1,104 @@
+---
+source: src/regression_tests/parser.rs
+description: lib.functionArgs (import ./x) ? muster
+---
+MemberCheck
+    [0;95;1m([0m Application
+        [0;96;1m([0m Term
+            [0;93;1m([0m Selection
+                [0;35m([0m Token
+                    [0;36m([0m Ann
+                        [0;33m{[0m preTrivia = fromList [0;35;1m[[0m[0;35;1m][0m
+                        [0;33m,[0m sourceLine = Pos [0;92;1m1[0m
+                        [0;33m,[0m value = Identifier [0;97;1m"[0m[0;94;1mlib[0m[0;97;1m"[0m
+                        [0;33m,[0m trailComment = Nothing
+                        [0;33m}[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+                [0;35m[[0m Selector
+                    [0;36m([0m Just
+                        [0;33m([0m Ann
+                            [0;35;1m{[0m preTrivia = fromList [0;36;1m[[0m[0;36;1m][0m
+                            [0;35;1m,[0m sourceLine = Pos [0;92;1m1[0m
+                            [0;35;1m,[0m value = TDot
+                            [0;35;1m,[0m trailComment = Nothing
+                            [0;35;1m}[0m
+                        [0;33m)[0m
+                    [0;36m)[0m
+                    [0;36m([0m IDSelector
+                        [0;33m([0m Ann
+                            [0;35;1m{[0m preTrivia = fromList [0;36;1m[[0m[0;36;1m][0m
+                            [0;35;1m,[0m sourceLine = Pos [0;92;1m1[0m
+                            [0;35;1m,[0m value = Identifier [0;97;1m"[0m[0;94;1mfunctionArgs[0m[0;97;1m"[0m
+                            [0;35;1m,[0m trailComment = Nothing
+                            [0;35;1m}[0m
+                        [0;33m)[0m
+                    [0;36m)[0m
+                [0;35m][0m Nothing
+            [0;93;1m)[0m
+        [0;96;1m)[0m
+        [0;96;1m([0m Term
+            [0;93;1m([0m Parenthesized
+                [0;35m([0m Ann
+                    [0;36m{[0m preTrivia = fromList [0;33m[[0m[0;33m][0m
+                    [0;36m,[0m sourceLine = Pos [0;92;1m1[0m
+                    [0;36m,[0m value = TParenOpen
+                    [0;36m,[0m trailComment = Nothing
+                    [0;36m}[0m
+                [0;35m)[0m
+                [0;35m([0m Application
+                    [0;36m([0m Term
+                        [0;33m([0m Token
+                            [0;35;1m([0m Ann
+                                [0;36;1m{[0m preTrivia = fromList [0;33;1m[[0m[0;33;1m][0m
+                                [0;36;1m,[0m sourceLine = Pos [0;92;1m1[0m
+                                [0;36;1m,[0m value = Identifier [0;97;1m"[0m[0;94;1mimport[0m[0;97;1m"[0m
+                                [0;36;1m,[0m trailComment = Nothing
+                                [0;36;1m}[0m
+                            [0;35;1m)[0m
+                        [0;33m)[0m
+                    [0;36m)[0m
+                    [0;36m([0m Term
+                        [0;33m([0m Path
+                            [0;35;1m([0m Ann
+                                [0;36;1m{[0m preTrivia = fromList [0;33;1m[[0m[0;33;1m][0m
+                                [0;36;1m,[0m sourceLine = Pos [0;92;1m1[0m
+                                [0;36;1m,[0m value =
+                                    [0;33;1m[[0m TextPart [0;97;1m"[0m[0;94;1m./x[0m[0;97;1m"[0m [0;33;1m][0m
+                                [0;36;1m,[0m trailComment = Nothing
+                                [0;36;1m}[0m
+                            [0;35;1m)[0m
+                        [0;33m)[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+                [0;35m([0m Ann
+                    [0;36m{[0m preTrivia = fromList [0;33m[[0m[0;33m][0m
+                    [0;36m,[0m sourceLine = Pos [0;92;1m1[0m
+                    [0;36m,[0m value = TParenClose
+                    [0;36m,[0m trailComment = Nothing
+                    [0;36m}[0m
+                [0;35m)[0m
+            [0;93;1m)[0m
+        [0;96;1m)[0m
+    [0;95;1m)[0m
+    [0;95;1m([0m
+        [0;96;1m([0m Ann
+            [0;93;1m{[0m preTrivia = fromList [0;35m[[0m[0;35m][0m
+            [0;93;1m,[0m sourceLine = Pos [0;92;1m1[0m
+            [0;93;1m,[0m value = TQuestion
+            [0;93;1m,[0m trailComment = Nothing
+            [0;93;1m}[0m
+        [0;96;1m,[0m
+            [0;93;1m[[0m Selector Nothing
+                [0;35m([0m IDSelector
+                    [0;36m([0m Ann
+                        [0;33m{[0m preTrivia = fromList [0;35;1m[[0m[0;35;1m][0m
+                        [0;33m,[0m sourceLine = Pos [0;92;1m1[0m
+                        [0;33m,[0m value = Identifier [0;97;1m"[0m[0;94;1mmuster[0m[0;97;1m"[0m
+                        [0;33m,[0m trailComment = Nothing
+                        [0;33m}[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+            [0;93;1m][0m
+        [0;96;1m)[0m :| [0;96;1m[[0m[0;96;1m][0m
+    [0;95;1m)[0m

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__parser__regression_has_attr_after_application-4.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__parser__regression_has_attr_after_application-4.snap
@@ -1,0 +1,71 @@
+---
+source: src/regression_tests/parser.rs
+description: f x ? a ? b
+---
+MemberCheck
+    [0;95;1m([0m Application
+        [0;96;1m([0m Term
+            [0;93;1m([0m Token
+                [0;35m([0m Ann
+                    [0;36m{[0m preTrivia = fromList [0;33m[[0m[0;33m][0m
+                    [0;36m,[0m sourceLine = Pos [0;92;1m1[0m
+                    [0;36m,[0m value = Identifier [0;97;1m"[0m[0;94;1mf[0m[0;97;1m"[0m
+                    [0;36m,[0m trailComment = Nothing
+                    [0;36m}[0m
+                [0;35m)[0m
+            [0;93;1m)[0m
+        [0;96;1m)[0m
+        [0;96;1m([0m Term
+            [0;93;1m([0m Token
+                [0;35m([0m Ann
+                    [0;36m{[0m preTrivia = fromList [0;33m[[0m[0;33m][0m
+                    [0;36m,[0m sourceLine = Pos [0;92;1m1[0m
+                    [0;36m,[0m value = Identifier [0;97;1m"[0m[0;94;1mx[0m[0;97;1m"[0m
+                    [0;36m,[0m trailComment = Nothing
+                    [0;36m}[0m
+                [0;35m)[0m
+            [0;93;1m)[0m
+        [0;96;1m)[0m
+    [0;95;1m)[0m
+    [0;95;1m([0m
+        [0;96;1m([0m Ann
+            [0;93;1m{[0m preTrivia = fromList [0;35m[[0m[0;35m][0m
+            [0;93;1m,[0m sourceLine = Pos [0;92;1m1[0m
+            [0;93;1m,[0m value = TQuestion
+            [0;93;1m,[0m trailComment = Nothing
+            [0;93;1m}[0m
+        [0;96;1m,[0m
+            [0;93;1m[[0m Selector Nothing
+                [0;35m([0m IDSelector
+                    [0;36m([0m Ann
+                        [0;33m{[0m preTrivia = fromList [0;35;1m[[0m[0;35;1m][0m
+                        [0;33m,[0m sourceLine = Pos [0;92;1m1[0m
+                        [0;33m,[0m value = Identifier [0;97;1m"[0m[0;94;1ma[0m[0;97;1m"[0m
+                        [0;33m,[0m trailComment = Nothing
+                        [0;33m}[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+            [0;93;1m][0m
+        [0;96;1m)[0m :|
+        [0;96;1m[[0m
+            [0;93;1m([0m Ann
+                [0;35m{[0m preTrivia = fromList [0;36m[[0m[0;36m][0m
+                [0;35m,[0m sourceLine = Pos [0;92;1m1[0m
+                [0;35m,[0m value = TQuestion
+                [0;35m,[0m trailComment = Nothing
+                [0;35m}[0m
+            [0;93;1m,[0m
+                [0;35m[[0m Selector Nothing
+                    [0;36m([0m IDSelector
+                        [0;33m([0m Ann
+                            [0;35;1m{[0m preTrivia = fromList [0;36;1m[[0m[0;36;1m][0m
+                            [0;35;1m,[0m sourceLine = Pos [0;92;1m1[0m
+                            [0;35;1m,[0m value = Identifier [0;97;1m"[0m[0;94;1mb[0m[0;97;1m"[0m
+                            [0;35;1m,[0m trailComment = Nothing
+                            [0;35;1m}[0m
+                        [0;33m)[0m
+                    [0;36m)[0m
+                [0;35m][0m
+            [0;93;1m)[0m
+        [0;96;1m][0m
+    [0;95;1m)[0m

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__parser__regression_has_attr_after_application-5.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__parser__regression_has_attr_after_application-5.snap
@@ -1,0 +1,68 @@
+---
+source: src/regression_tests/parser.rs
+description: (f x) ? a
+---
+MemberCheck
+    [0;95;1m([0m Term
+        [0;96;1m([0m Parenthesized
+            [0;93;1m([0m Ann
+                [0;35m{[0m preTrivia = fromList [0;36m[[0m[0;36m][0m
+                [0;35m,[0m sourceLine = Pos [0;92;1m1[0m
+                [0;35m,[0m value = TParenOpen
+                [0;35m,[0m trailComment = Nothing
+                [0;35m}[0m
+            [0;93;1m)[0m
+            [0;93;1m([0m Application
+                [0;35m([0m Term
+                    [0;36m([0m Token
+                        [0;33m([0m Ann
+                            [0;35;1m{[0m preTrivia = fromList [0;36;1m[[0m[0;36;1m][0m
+                            [0;35;1m,[0m sourceLine = Pos [0;92;1m1[0m
+                            [0;35;1m,[0m value = Identifier [0;97;1m"[0m[0;94;1mf[0m[0;97;1m"[0m
+                            [0;35;1m,[0m trailComment = Nothing
+                            [0;35;1m}[0m
+                        [0;33m)[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+                [0;35m([0m Term
+                    [0;36m([0m Token
+                        [0;33m([0m Ann
+                            [0;35;1m{[0m preTrivia = fromList [0;36;1m[[0m[0;36;1m][0m
+                            [0;35;1m,[0m sourceLine = Pos [0;92;1m1[0m
+                            [0;35;1m,[0m value = Identifier [0;97;1m"[0m[0;94;1mx[0m[0;97;1m"[0m
+                            [0;35;1m,[0m trailComment = Nothing
+                            [0;35;1m}[0m
+                        [0;33m)[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+            [0;93;1m)[0m
+            [0;93;1m([0m Ann
+                [0;35m{[0m preTrivia = fromList [0;36m[[0m[0;36m][0m
+                [0;35m,[0m sourceLine = Pos [0;92;1m1[0m
+                [0;35m,[0m value = TParenClose
+                [0;35m,[0m trailComment = Nothing
+                [0;35m}[0m
+            [0;93;1m)[0m
+        [0;96;1m)[0m
+    [0;95;1m)[0m
+    [0;95;1m([0m
+        [0;96;1m([0m Ann
+            [0;93;1m{[0m preTrivia = fromList [0;35m[[0m[0;35m][0m
+            [0;93;1m,[0m sourceLine = Pos [0;92;1m1[0m
+            [0;93;1m,[0m value = TQuestion
+            [0;93;1m,[0m trailComment = Nothing
+            [0;93;1m}[0m
+        [0;96;1m,[0m
+            [0;93;1m[[0m Selector Nothing
+                [0;35m([0m IDSelector
+                    [0;36m([0m Ann
+                        [0;33m{[0m preTrivia = fromList [0;35;1m[[0m[0;35;1m][0m
+                        [0;33m,[0m sourceLine = Pos [0;92;1m1[0m
+                        [0;33m,[0m value = Identifier [0;97;1m"[0m[0;94;1ma[0m[0;97;1m"[0m
+                        [0;33m,[0m trailComment = Nothing
+                        [0;33m}[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+            [0;93;1m][0m
+        [0;96;1m)[0m :| [0;96;1m[[0m[0;96;1m][0m
+    [0;95;1m)[0m

--- a/src/regression_tests/snapshots/nixfmt_rs__regression_tests__parser__regression_has_attr_after_application.snap
+++ b/src/regression_tests/snapshots/nixfmt_rs__regression_tests__parser__regression_has_attr_after_application.snap
@@ -1,0 +1,50 @@
+---
+source: src/regression_tests/parser.rs
+description: f x ? a
+---
+MemberCheck
+    [0;95;1m([0m Application
+        [0;96;1m([0m Term
+            [0;93;1m([0m Token
+                [0;35m([0m Ann
+                    [0;36m{[0m preTrivia = fromList [0;33m[[0m[0;33m][0m
+                    [0;36m,[0m sourceLine = Pos [0;92;1m1[0m
+                    [0;36m,[0m value = Identifier [0;97;1m"[0m[0;94;1mf[0m[0;97;1m"[0m
+                    [0;36m,[0m trailComment = Nothing
+                    [0;36m}[0m
+                [0;35m)[0m
+            [0;93;1m)[0m
+        [0;96;1m)[0m
+        [0;96;1m([0m Term
+            [0;93;1m([0m Token
+                [0;35m([0m Ann
+                    [0;36m{[0m preTrivia = fromList [0;33m[[0m[0;33m][0m
+                    [0;36m,[0m sourceLine = Pos [0;92;1m1[0m
+                    [0;36m,[0m value = Identifier [0;97;1m"[0m[0;94;1mx[0m[0;97;1m"[0m
+                    [0;36m,[0m trailComment = Nothing
+                    [0;36m}[0m
+                [0;35m)[0m
+            [0;93;1m)[0m
+        [0;96;1m)[0m
+    [0;95;1m)[0m
+    [0;95;1m([0m
+        [0;96;1m([0m Ann
+            [0;93;1m{[0m preTrivia = fromList [0;35m[[0m[0;35m][0m
+            [0;93;1m,[0m sourceLine = Pos [0;92;1m1[0m
+            [0;93;1m,[0m value = TQuestion
+            [0;93;1m,[0m trailComment = Nothing
+            [0;93;1m}[0m
+        [0;96;1m,[0m
+            [0;93;1m[[0m Selector Nothing
+                [0;35m([0m IDSelector
+                    [0;36m([0m Ann
+                        [0;33m{[0m preTrivia = fromList [0;35;1m[[0m[0;35;1m][0m
+                        [0;33m,[0m sourceLine = Pos [0;92;1m1[0m
+                        [0;33m,[0m value = Identifier [0;97;1m"[0m[0;94;1ma[0m[0;97;1m"[0m
+                        [0;33m,[0m trailComment = Nothing
+                        [0;33m}[0m
+                    [0;36m)[0m
+                [0;35m)[0m
+            [0;93;1m][0m
+        [0;96;1m)[0m :| [0;96;1m[[0m[0;96;1m][0m
+    [0;95;1m)[0m


### PR DESCRIPTION
`f x ? a` is valid Nix, but nixfmt-rs rejects it. On current `main` (0.5.2):

```console
$ echo 'lib.optionalAttrs (lib.functionArgs (import ./x) ? muster) { }' | nixfmt -
Error[E001]: expected ')', found '?'
   ┌─ <stdin>:1:47
   │
 1 │ lib.optionalAttrs (lib.functionArgs (import ./x) ? muster) { }
   │                                                  ^
```

`nix` parses that expression, and so does nixfmt 1.4.0. It is how you ask whether a function takes a named argument, so it turns up in real trees — I hit it on a `package.nix` of my own, and it cost the repo its formatter until someone read the parser.

### Cause

Two parser paths must agree on where postfix `?` binds, and they do not:

* `term.rs::parse_application` consumes the argument terms first, **then** tests for `Token::Question`. Right order.
* `operators.rs::continue_operation_from` tests for `Token::Question` **first**, in an `if`/`else if` whose other arm is the application loop. Once that loop has run, nothing looks for `?` again.

An expression whose head is a bare identifier reaches the second path, so `f x ? a` loses its `?`. `(f x) ? a` survives only because a parenthesised head is a term, which puts the `?` at the front where the test still sees it.

### Fix

Move the test after the loop, matching `parse_application`. This is not a new rule, it is the same rule spelled once more: `?` is not a term start, so the loop already stops on it, and the test that follows sees exactly the token the old code was looking at. Where the old code took its `?` branch — application loop empty — the new code takes the same branch with the same operand, so already-accepted input parses to the identical tree.

### Evidence

* Formatting output is **byte-identical** before and after over all **43,325** `.nix` files in nixpkgs, with no input newly rejected (patched and stock binaries run side by side over the whole tree).
* On my own tree: 193 of 194 files byte-identical, and the one that changed is the one that used to fail to parse.
* `cargo test` passes (293 + 5 + 26 + 2), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.

Regression cases are in `src/regression_tests/parser.rs` with AST snapshots, per `tests/README.md` tier 2 — including the chained form `f x ? a ? b`, which now attaches both checks to the application.
